### PR TITLE
Fix OSO Proxy spin out of control when 'target' is not configured

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -14,6 +14,7 @@ RUN yum --enablerepo=centosplus install -y \
       tar \
       wget \
       which \
+      gcc \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -7,7 +7,7 @@ ENV INSTALL_PREFIX=/usr/local/fabric8-osoproxy
 ENV F8_USER_NAME=fabric8
 RUN useradd --no-create-home -s /bin/bash ${F8_USER_NAME}
 
-COPY traefik ${INSTALL_PREFIX}/bin/fabric8-osoproxy
+COPY dist/traefik ${INSTALL_PREFIX}/bin/fabric8-osoproxy
 
 # Install little pcp pmcd server for metrics collection
 # would prefer only pmcd, and not the /bin/pm*tools etc.

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -22,3 +22,4 @@ docker exec -t "$BUILDER-run" bash -ec 'go get github.com/jteeuwen/go-bindata/..
 docker exec -t "$BUILDER-run" bash -ec 'go generate'
 docker exec -t "$BUILDER-run" bash -ec 'go build ./cmd/traefik'
 docker exec -t "$BUILDER-run" bash -ec 'go test -v ./middlewares/osio/'
+docker exec -t "$BUILDER-run" bash -ec 'go test -v ./integration/ -integration -osio'

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -20,6 +20,6 @@ docker run --detach=true -t \
 
 docker exec -t "$BUILDER-run" bash -ec 'go get github.com/jteeuwen/go-bindata/...'
 docker exec -t "$BUILDER-run" bash -ec 'go generate'
-docker exec -t "$BUILDER-run" bash -ec 'go build ./cmd/traefik'
+docker exec -t "$BUILDER-run" bash -ec 'go build -o dist/traefik ./cmd/traefik'
 docker exec -t "$BUILDER-run" bash -ec 'go test -v ./middlewares/osio/'
 docker exec -t "$BUILDER-run" bash -ec 'go test -v ./integration/ -integration -osio'

--- a/integration/fixtures/osio_config.toml
+++ b/integration/fixtures/osio_config.toml
@@ -1,0 +1,41 @@
+logLevel = "ERROR"
+defaultEntryPoints = ["http"]
+[entryPoints]
+  [entryPoints.http]
+  address = ":8000"
+  [entryPoints.traefik]
+  address = ":7888"
+
+checkNewVersion = false
+
+[api]
+entryPoint = "traefik"
+
+[file]
+watch = false
+
+# rules
+[backends]
+  [backends.default]
+    [backends.default.servers.server1]
+    url = "http://127.0.0.1:8081"
+  [backends.backend1]
+    [backends.backend1.servers.server1]
+    url = "http://127.0.0.1:8081"
+  [backends.backend2]
+    [backends.backend2.servers.server1]
+    url = "http://127.0.0.1:8082"
+
+[frontends]
+  [frontends.default]
+  backend = "default"
+    [frontends.default.routes.test_1]
+    rule = "HeadersRegexp:Target,default"
+  [frontends.frontend1]
+  backend = "backend1"
+    [frontends.frontend1.routes.test_1]
+    rule = "HeadersRegexp:Target,http://127.0.0.1:8081"
+  [frontends.frontend2]
+  backend = "backend2"
+    [frontends.frontend2.routes.test_1]
+    rule = "HeadersRegexp:Target,http://127.0.0.1:8082"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -22,6 +22,7 @@ import (
 var integration = flag.Bool("integration", false, "run integration tests")
 var container = flag.Bool("container", false, "run container integration tests")
 var host = flag.Bool("host", false, "run host integration tests")
+var osio = flag.Bool("osio", false, "run osio integration tests")
 
 func Test(t *testing.T) {
 	check.TestingT(t)
@@ -62,6 +63,10 @@ func init() {
 		// tests launched from the host
 		check.Suite(&ProxyProtocolSuite{})
 		check.Suite(&Etcd3Suite{})
+	}
+
+	if *osio {
+		check.Suite(&OSIOSuite{})
 	}
 }
 

--- a/integration/osio_test.go
+++ b/integration/osio_test.go
@@ -1,0 +1,125 @@
+package integration
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/containous/traefik/integration/try"
+	"github.com/containous/traefik/log"
+	"github.com/go-check/check"
+	checker "github.com/vdemeester/shakers"
+)
+
+const (
+	witURL  = "http://127.0.0.1:9090"
+	authURL = "http://127.0.0.1:9091"
+)
+
+// AccessLogSuite
+type OSIOSuite struct{ BaseSuite }
+
+func (s *OSIOSuite) TestOSIO(c *check.C) {
+	// configure OSIO
+	os.Setenv("WIT_URL", witURL)
+	os.Setenv("AUTH_URL", authURL)
+	witServer := startOSIOServer(9090, serveWITRequest)
+	defer witServer.Close()
+	authServer := startOSIOServer(9091, serverAUTHRequest)
+	defer authServer.Close()
+
+	// Start Traefik
+	cmd, display := s.traefikCmd(withConfigFile("fixtures/osio_config.toml"))
+	defer display(c)
+	err := cmd.Start()
+	c.Assert(err, checker.IsNil)
+	defer cmd.Process.Kill()
+
+	// Start OSIO servers
+	ts1 := startOSIOServer(8081, nil)
+	defer ts1.Close()
+	ts2 := startOSIOServer(8082, nil)
+	defer ts2.Close()
+
+	// Make some requests
+	req, _ := http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
+	req.Header.Add("Authorization", "Bearer 1111")
+	res, err := try.Response(req, 500*time.Millisecond)
+	c.Assert(err, check.IsNil)
+	log.Printf("req1 res.StatusCode=%d", res.StatusCode)
+	c.Assert(res.StatusCode, check.Equals, 200)
+	checkPort(c, res, 8081)
+
+	req, _ = http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
+	req.Header.Add("Authorization", "Bearer 2222")
+	res, _ = try.Response(req, 500*time.Millisecond)
+	c.Assert(err, check.IsNil)
+	log.Printf("req2 res.StatusCode=%d", res.StatusCode)
+	c.Assert(res.StatusCode, check.Equals, 200)
+	checkPort(c, res, 8082)
+
+	req, _ = http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
+	req.Header.Add("Authorization", "Bearer 3333")
+	res, _ = try.Response(req, 500*time.Millisecond)
+	c.Assert(err, check.IsNil)
+	log.Printf("req3 res.StatusCode=%d", res.StatusCode)
+	c.Assert(res.StatusCode, check.Equals, 404)
+
+	req, _ = http.NewRequest("OPTIONS", "http://127.0.0.1:8000/test", nil)
+	// req.Header.Add("Authorization", "Bearer 1111")
+	res, _ = try.Response(req, 500*time.Millisecond)
+	c.Assert(err, check.IsNil)
+	log.Printf("req4 res.StatusCode=%d", res.StatusCode)
+	c.Assert(res.StatusCode, check.Equals, 200)
+	checkPort(c, res, 8081)
+}
+
+func checkPort(c *check.C, res *http.Response, expectedPort int) {
+	c.Assert(res, check.NotNil)
+	body := make([]byte, res.ContentLength)
+	res.Body.Read(body)
+	if !strings.HasSuffix(string(body), strconv.Itoa(expectedPort)) {
+		c.Errorf("Served by wrong port, want:%d, got:%s", expectedPort, string(body))
+	}
+}
+
+func startOSIOServer(port int, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
+	if handler == nil {
+		handler = func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "port=%d", port)
+		}
+	}
+	if listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port)); err != nil {
+		panic(err)
+	} else {
+		ts = &httptest.Server{
+			Listener: listener,
+			Config:   &http.Server{Handler: http.HandlerFunc(handler)},
+		}
+		ts.Start()
+	}
+	return
+}
+
+func serveWITRequest(rw http.ResponseWriter, req *http.Request) {
+	authHeader := req.Header.Get("Authorization")
+	host := ""
+	if strings.HasSuffix(authHeader, "1111") {
+		host = "http://127.0.0.1:8081"
+	} else if strings.HasSuffix(authHeader, "2222") {
+		host = "http://127.0.0.1:8082"
+	} else if strings.HasSuffix(authHeader, "3333") {
+		host = "http://127.0.0.1:8083" // :8083 is not present in toml file
+	}
+
+	res := "{\"data\":{\"attributes\":{\"namespaces\":[{\"cluster-url\":\"" + host + "/\"}]}}}"
+	rw.Write([]byte(res))
+}
+
+func serverAUTHRequest(rw http.ResponseWriter, req *http.Request) {
+}

--- a/middlewares/osio/auth.go
+++ b/middlewares/osio/auth.go
@@ -80,13 +80,13 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 		if r.Method != "OPTIONS" {
 			osioToken, err := getToken(r)
 			if err != nil {
-				rw.WriteHeader(401)
+				rw.WriteHeader(http.StatusUnauthorized)
 				return
 			}
 
 			cached, err := a.resolve(osioToken)
 			if err != nil {
-				rw.WriteHeader(401)
+				rw.WriteHeader(http.StatusUnauthorized)
 				return
 			}
 			r.Header.Set("Target", cached.Location)
@@ -106,6 +106,9 @@ func getToken(r *http.Request) (string, error) {
 	t, err := extractToken(r.Header.Get(Authorization))
 	if err != nil {
 		return "", err
+	}
+	if t == "" {
+		return "", fmt.Errorf("Missing auth")
 	}
 	return t, nil
 }

--- a/middlewares/osio/auth.go
+++ b/middlewares/osio/auth.go
@@ -58,7 +58,6 @@ func cacheResolver(locationLocator TenantLocator, tokenLocator TenantTokenLocato
 		if err != nil {
 			return cacheData{}, err
 		}
-		fmt.Println("resolved..")
 		return cacheData{Location: loc, Token: osoToken}, nil
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Previously OSIO auth middleware added as side effect of specifying frontends in toml file.
Now, OSIO auth middleware added as standard middleware.

### Motivation
Fix issue - https://github.com/openshiftio/openshift.io/issues/2693

As OSIS auth middleware added as frontends, treafik used to give two calls to OSIO auth.  First being middleware and second being one of the frontends matching.  Also, This OSIO frontends routes request to localhost (self) which sometime may result into calling localhost infinitely.  One of the such cases was when Target set by OSIO not configured as frontends in toml file.

### More
Here is the before after treafik logs through which we can see the routing done by treafik.

**frontends - positive 200 ok:**
```
{"BackendAddr":"localhost:8080","BackendName":"auth","BackendURL":{"Scheme":"http","Opaque":"","User":null,"Host":"localhost:8080","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":""},"ClientAddr":"[::1]:36998","ClientHost":"::1","ClientPort":"36998","ClientUsername":"-","DownstreamContentSize":2,"DownstreamStatus":200,"DownstreamStatusLine":"200 OK","Duration":4375509550,"FrontendName":"auth","OriginContentSize":2,"OriginDuration":1330717775,"OriginStatus":200,"OriginStatusLine":"200 OK","Overhead":3044791775,"RequestAddr":"localhost:8080","RequestContentSize":0,"RequestCount":1,"RequestHost":"localhost","RequestLine":"GET /healthz/ready HTTP/1.1","RequestMethod":"GET","RequestPath":"/healthz/ready","RequestPort":"8080","RequestProtocol":"HTTP/1.1","RetryAttempts":0,"StartLocal":"2018-04-02T14:37:54.30386756+05:30","StartUTC":"2018-04-02T09:07:54.30386756Z","downstream_Cache-Control":"no-store","downstream_Content-Length":"2","downstream_Content-Type":"text/plain; charset=utf-8","downstream_Date":"Mon, 02 Apr 2018 09:07:58 GMT","level":"info","msg":"","origin_Cache-Control":"no-store","origin_Content-Length":"2","origin_Content-Type":"text/plain; charset=utf-8","origin_Date":"Mon, 02 Apr 2018 09:07:58 GMT","request_Accept":"*/*","request_Authorization":"Bearer <actual_token>","request_Target":"https://api.starter-us-east-2a.openshift.com/","request_User-Agent":"curl/7.55.1","request_X-Forwarded-Prefix":"/","time":"2018-04-02T14:37:58+05:30"}
{"BackendAddr":"api.starter-us-east-2a.openshift.com","BackendName":"backend4","BackendURL":{"Scheme":"https","Opaque":"","User":null,"Host":"api.starter-us-east-2a.openshift.com","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":""},"ClientAddr":"[::1]:37004","ClientHost":"::1","ClientPort":"37004","ClientUsername":"-","DownstreamContentSize":2,"DownstreamStatus":200,"DownstreamStatusLine":"200 OK","Duration":1327251537,"FrontendName":"frontend4","OriginContentSize":2,"OriginDuration":1326836372,"OriginStatus":200,"OriginStatusLine":"200 OK","Overhead":415165,"RequestAddr":"localhost:8080","RequestContentSize":0,"RequestCount":2,"RequestHost":"localhost","RequestLine":"GET /healthz/ready HTTP/1.1","RequestMethod":"GET","RequestPath":"/healthz/ready","RequestPort":"8080","RequestProtocol":"HTTP/1.1","RetryAttempts":0,"StartLocal":"2018-04-02T14:37:57.350828639+05:30","StartUTC":"2018-04-02T09:07:57.350828639Z","downstream_Cache-Control":"no-store","downstream_Content-Length":"2","downstream_Content-Type":"text/plain; charset=utf-8","downstream_Date":"Mon, 02 Apr 2018 09:07:58 GMT","level":"info","msg":"","origin_Cache-Control":"no-store","origin_Content-Length":"2","origin_Content-Type":"text/plain; charset=utf-8","origin_Date":"Mon, 02 Apr 2018 09:07:58 GMT","request_Accept":"*/*","request_Accept-Encoding":"gzip","request_Authorization":"Bearer <actual_token>","request_Target":"https://api.starter-us-east-2a.openshift.com/","request_User-Agent":"curl/7.55.1","request_X-Forwarded-For":"::1","request_X-Forwarded-Host":"localhost:8080","request_X-Forwarded-Port":"8080","request_X-Forwarded-Prefix":"/","request_X-Forwarded-Proto":"http","request_X-Forwarded-Server":"localhost.localdomain","request_X-Real-Ip":"::1","time":"2018-04-02T14:37:58+05:30"}
```

**middleware - positive 200 ok:**
```
{"BackendAddr":"api.starter-us-east-2a.openshift.com","BackendName":"backend4","BackendURL":{"Scheme":"https","Opaque":"","User":null,"Host":"api.starter-us-east-2a.openshift.com","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":""},"ClientAddr":"[::1]:36952","ClientHost":"::1","ClientPort":"36952","ClientUsername":"-","DownstreamContentSize":2,"DownstreamStatus":200,"DownstreamStatusLine":"200 OK","Duration":5605053726,"FrontendName":"frontend4","OriginContentSize":2,"OriginDuration":1520927095,"OriginStatus":200,"OriginStatusLine":"200 OK","Overhead":4084126631,"RequestAddr":"localhost:8080","RequestContentSize":0,"RequestCount":1,"RequestHost":"localhost","RequestLine":"GET /healthz/ready HTTP/1.1","RequestMethod":"GET","RequestPath":"/healthz/ready","RequestPort":"8080","RequestProtocol":"HTTP/1.1","RetryAttempts":0,"StartLocal":"2018-04-02T14:34:52.235078388+05:30","StartUTC":"2018-04-02T09:04:52.235078388Z","downstream_Cache-Control":"no-store","downstream_Content-Length":"2","downstream_Content-Type":"text/plain; charset=utf-8","downstream_Date":"Mon, 02 Apr 2018 09:04:57 GMT","level":"info","msg":"","origin_Cache-Control":"no-store","origin_Content-Length":"2","origin_Content-Type":"text/plain; charset=utf-8","origin_Date":"Mon, 02 Apr 2018 09:04:57 GMT","request_Accept":"*/*","request_Authorization":"Bearer <actual_token>","request_Target":"https://api.starter-us-east-2a.openshift.com/","request_User-Agent":"curl/7.55.1","time":"2018-04-02T14:34:57+05:30"}
```

**Note**
In case of frontends two routing,
localhost ->  api.starter-us-east-2a.openshift.com

In case of middleware one routing,
api.starter-us-east-2a.openshift.com

**frontends - negative 401 Unauthorized:**
```
{"ClientAddr":"[::1]:37038","ClientHost":"::1","ClientPort":"37038","ClientUsername":"-","DownstreamContentSize":0,"DownstreamStatus":401,"DownstreamStatusLine":"401 Unauthorized","Duration":381554252,"Overhead":381554252,"RequestAddr":"localhost:8080","RequestContentSize":0,"RequestCount":2,"RequestHost":"localhost","RequestLine":"GET /healthz/ready HTTP/1.1","RequestMethod":"GET","RequestPath":"/healthz/ready","RequestPort":"8080","RequestProtocol":"HTTP/1.1","RetryAttempts":0,"StartLocal":"2018-04-02T14:39:07.800392342+05:30","StartUTC":"2018-04-02T09:09:07.800392342Z","level":"info","msg":"","request_Accept":"*/*","request_Accept-Encoding":"gzip","request_Authorization":"Bearer <actual_token>","request_Target":"https://api.starter-us-east-2a.openshift.com/","request_User-Agent":"curl/7.55.1","request_X-Forwarded-For":"::1","request_X-Forwarded-Host":"localhost:8080","request_X-Forwarded-Port":"8080","request_X-Forwarded-Prefix":"/","request_X-Forwarded-Proto":"http","request_X-Forwarded-Server":"localhost.localdomain","request_X-Real-Ip":"::1","time":"2018-04-02T14:39:08+05:30"}
{"BackendAddr":"localhost:8080","BackendName":"auth","BackendURL":{"Scheme":"http","Opaque":"","User":null,"Host":"localhost:8080","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":""},"ClientAddr":"[::1]:37030","ClientHost":"::1","ClientPort":"37030","ClientUsername":"-","DownstreamContentSize":0,"DownstreamStatus":401,"DownstreamStatusLine":"401 Unauthorized","Duration":3352836374,"FrontendName":"auth","OriginContentSize":0,"OriginDuration":385083744,"OriginStatus":401,"OriginStatusLine":"401 Unauthorized","Overhead":2967752630,"RequestAddr":"localhost:8080","RequestContentSize":0,"RequestCount":1,"RequestHost":"localhost","RequestLine":"GET /healthz/ready HTTP/1.1","RequestMethod":"GET","RequestPath":"/healthz/ready","RequestPort":"8080","RequestProtocol":"HTTP/1.1","RetryAttempts":0,"StartLocal":"2018-04-02T14:39:04.830166477+05:30","StartUTC":"2018-04-02T09:09:04.830166477Z","downstream_Content-Length":"0","downstream_Date":"Mon, 02 Apr 2018 09:09:08 GMT","level":"info","msg":"","origin_Content-Length":"0","origin_Date":"Mon, 02 Apr 2018 09:09:08 GMT","request_Accept":"*/*","request_Authorization":"Bearer <actual_token>","request_Target":"https://api.starter-us-east-2a.openshift.com/","request_User-Agent":"curl/7.55.1","request_X-Forwarded-Prefix":"/","time":"2018-04-02T14:39:08+05:30"}
```

**middleware - negative 404 not found:**
```
{"ClientAddr":"[::1]:36970","ClientHost":"::1","ClientPort":"36970","ClientUsername":"-","DownstreamContentSize":19,"DownstreamStatus":404,"DownstreamStatusLine":"404 Not Found","Duration":3268280940,"Overhead":3268280940,"RequestAddr":"localhost:8080","RequestContentSize":0,"RequestCount":1,"RequestHost":"localhost","RequestLine":"GET /healthz/ready HTTP/1.1","RequestMethod":"GET","RequestPath":"/healthz/ready","RequestPort":"8080","RequestProtocol":"HTTP/1.1","RetryAttempts":0,"StartLocal":"2018-04-02T14:35:58.57128439+05:30","StartUTC":"2018-04-02T09:05:58.57128439Z","downstream_Content-Type":"text/plain; charset=utf-8","downstream_X-Content-Type-Options":"nosniff","level":"info","msg":"","request_Accept":"*/*","request_Authorization":"Bearer <actual_token>","request_Target":"https://api.starter-us-east-2a.openshift.com/","request_User-Agent":"curl/7.55.1","time":"2018-04-02T14:36:01+05:30"}
```

**Note:** There is one route in case of frontends. 