### PR TITLE
Fix double slash Target URL issue causing 404 in OSO

### DIFF
--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -23,13 +23,13 @@ var cheDataTables = []testCheData{
 	{
 		"/api",
 		"john",
-		"127.0.0.1:9091",
+		"127.0.0.1:9091/",
 		"1000_che_secret",
 	},
 	{
 		"/api",
 		"john",
-		"127.0.0.1:9091",
+		"127.0.0.1:9091/",
 		"1000_che_secret",
 	},
 }
@@ -58,7 +58,7 @@ func TestBasic(t *testing.T) {
 
 	for ind, table := range cheDataTables {
 		currCheTestInd = ind
-		cluster := startServer(table.expectedTarget, serverClusterReqeust)
+		cluster := startServer(table.expectedTarget, serverClusterRequest)
 
 		currReqPath := table.inputPath
 		cheSAToken := "1000_che_sa_token"
@@ -114,7 +114,7 @@ func serverTenantRequest(rw http.ResponseWriter, req *http.Request) {
 						{
 							"name": "john-preview-che",
 							"type": "che",
-							"cluster-url": "http://127.0.0.1:9091"
+							"cluster-url": "http://127.0.0.1:9091/"
 						}
 					]
 				}
@@ -124,7 +124,7 @@ func serverTenantRequest(rw http.ResponseWriter, req *http.Request) {
 	rw.Write([]byte(res))
 }
 
-func serverClusterReqeust(rw http.ResponseWriter, req *http.Request) {
+func serverClusterRequest(rw http.ResponseWriter, req *http.Request) {
 	res := ""
 	if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/serviceaccounts/che") {
 		res = `{
@@ -209,7 +209,7 @@ func varifyHandler(rw http.ResponseWriter, req *http.Request) {
 }
 
 func startServer(url string, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
-	if listener, err := net.Listen("tcp", url); err != nil {
+	if listener, err := net.Listen("tcp", strings.Replace(url, "/", "", -1)); err != nil {
 		panic(err)
 	} else {
 		ts = &httptest.Server{

--- a/middlewares/osio/secret.go
+++ b/middlewares/osio/secret.go
@@ -36,7 +36,7 @@ func CreateSecretLocator(client *http.Client) SecretLocator {
 func (s *secretLocator) GetName(clusterUrl, clusterToken, nsName, nsType string) (string, error) {
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/nvirani-preview-che/serviceaccounts/che
 	// TODO: NT: nsType not used
-	url := fmt.Sprintf("%s/api/v1/namespaces/%s/serviceaccounts/che", clusterUrl, nsName)
+	url := fmt.Sprintf("%sapi/v1/namespaces/%s/serviceaccounts/che", clusterUrl, nsName)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -58,7 +58,7 @@ func (s *secretLocator) GetName(clusterUrl, clusterToken, nsName, nsType string)
 
 func (s *secretLocator) GetSecret(clusterUrl, clusterToken, nsName, secretName string) (string, error) {
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/nvirani-preview-che/secrets/che-token-w6h6f
-	url := fmt.Sprintf("%s/api/v1/namespaces/%s/secrets/%s", clusterUrl, nsName, secretName)
+	url := fmt.Sprintf("%sapi/v1/namespaces/%s/secrets/%s", clusterUrl, nsName, secretName)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
ClusterURL=https://xxx/

ClusterURL + '/api/' = https://xxx//api

Related to openshiftio/openshift.io#3417
