### PR TITLE
Remove 'Impersonate-User' header

### DIFF
--- a/middlewares/osio/auth.go
+++ b/middlewares/osio/auth.go
@@ -192,8 +192,12 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 				rw.WriteHeader(http.StatusUnauthorized)
 				return
 			}
+
 			r.Header.Set("Target", cached.Location)
 			r.Header.Set("Authorization", "Bearer "+cached.Token)
+			if isSerivce {
+				r.Header.Del(UserIDHeader)
+			}
 		} else {
 			r.Header.Set("Target", "default")
 		}

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -204,6 +204,11 @@ func varifyHandler(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Set("err", fmt.Sprintf("Token was incorrect, want:%s, got:%s", expectedToken, actualToken))
 		return
 	}
+	userID := req.Header.Get(UserIDHeader)
+	if userID != "" {
+		rw.Header().Set("err", fmt.Sprintf("%s header should not be set, want:%s, got:%s", UserIDHeader, "", userID))
+		return
+	}
 }
 
 func startServer(url string, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {


### PR DESCRIPTION
During integration test between che and oso-proxy, che was getting response code 403.  It seems that after setting user specific auth in oso-proxy, we should remove header 'Impersonate-User'.

Minor changes on top of PR - https://github.com/fabric8-services/fabric8-oso-proxy/pull/15
