### PR TITLE
Issue fixed when GetSecret gives 404

### DIFF
--- a/integration/common/osio.go
+++ b/integration/common/osio.go
@@ -60,7 +60,19 @@ func ServeTenantRequest(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	res := "{\"data\":{\"attributes\":{\"namespaces\":[{\"cluster-url\":\"" + host + "/\"}]}}}"
+	res := fmt.Sprintf(`{
+		"data": {
+			"attributes": {
+				"namespaces": [
+					{
+						"name": "john-preview",
+						"type": "user",
+						"cluster-url": "%s/"
+					}
+				]
+			}
+		}
+	}`, host)
 	rw.Write([]byte(res))
 }
 

--- a/middlewares/osio/auth.go
+++ b/middlewares/osio/auth.go
@@ -16,9 +16,21 @@ const (
 	UserIDHeader  = "Impersonate-User"
 )
 
+const (
+	// service maps to token type, if not a service token then it maps to UserToken
+	CheToken  TokenType = "che"
+	UserToken TokenType = "user"
+)
+
+var TokenTypeMap = map[string]TokenType{
+	"rh-che": CheToken,
+}
+
+type TokenType string
+
 type TenantLocator interface {
-	GetTenant(token string) (namespace, error)
-	GetTenantById(token, userID string) (namespace, error)
+	GetTenant(token string, tokenType TokenType) (namespace, error)
+	GetTenantById(token string, tokenType TokenType, userID string) (namespace, error)
 }
 
 type TenantTokenLocator interface {
@@ -33,7 +45,7 @@ type SecretLocator interface {
 	GetSecret(clusterUrl, clusterToken, nsName, secretName string) (string, error)
 }
 
-type SrvAccTokenChecker func(string) (bool, error)
+type TokenTypeLocator func(string) (TokenType, error)
 
 type cacheData struct {
 	Token    string
@@ -45,7 +57,7 @@ type OSIOAuth struct {
 	RequestTenantToken    TenantTokenLocator
 	RequestSrvAccToken    SrvAccTokenLocator
 	RequestSecretLocation SecretLocator
-	CheckSrvAccToken      SrvAccTokenChecker
+	RequestTokenType      TokenTypeLocator
 	cache                 *Cache
 }
 
@@ -80,14 +92,14 @@ func NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret string) *OSIOAuth {
 		RequestTenantToken:    CreateTenantTokenLocator(http.DefaultClient, authURL),
 		RequestSrvAccToken:    CreateSrvAccTokenLocator(authURL, srvAccID, srvAccSecret),
 		RequestSecretLocation: CreateSecretLocator(http.DefaultClient),
-		CheckSrvAccToken:      CreateSrvAccTokenChecker(http.DefaultClient, authURL),
+		RequestTokenType:      CreateTokenTypeLocator(http.DefaultClient, authURL),
 		cache:                 &Cache{},
 	}
 }
 
-func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, srvAccTokenLocator SrvAccTokenLocator, secretLocator SecretLocator, token, userID string) Resolver {
+func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, srvAccTokenLocator SrvAccTokenLocator, secretLocator SecretLocator, token string, tokenType TokenType, userID string) Resolver {
 	return func() (interface{}, error) {
-		ns, err := tenantLocator.GetTenantById(token, userID)
+		ns, err := tenantLocator.GetTenantById(token, tokenType, userID)
 		if err != nil {
 			log.Errorf("Failed to locate tenant, %v", err)
 			return cacheData{}, err
@@ -117,9 +129,9 @@ func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLoca
 	}
 }
 
-func cacheResolverByToken(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, token string) Resolver {
+func cacheResolverByToken(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, token string, tokenType TokenType) Resolver {
 	return func() (interface{}, error) {
-		ns, err := tenantLocator.GetTenant(token)
+		ns, err := tenantLocator.GetTenant(token, tokenType)
 		if err != nil {
 			log.Errorf("Failed to locate tenant, %v", err)
 			return cacheData{}, err
@@ -134,9 +146,9 @@ func cacheResolverByToken(tenantLocator TenantLocator, tokenLocator TenantTokenL
 	}
 }
 
-func (a *OSIOAuth) resolveByToken(token string) (cacheData, error) {
+func (a *OSIOAuth) resolveByToken(token string, tokenType TokenType) (cacheData, error) {
 	key := cacheKey(token)
-	val, err := a.cache.Get(key, cacheResolverByToken(a.RequestTenantLocation, a.RequestTenantToken, token)).Get()
+	val, err := a.cache.Get(key, cacheResolverByToken(a.RequestTenantLocation, a.RequestTenantToken, token, tokenType)).Get()
 
 	if data, ok := val.(cacheData); ok {
 		return data, err
@@ -144,10 +156,10 @@ func (a *OSIOAuth) resolveByToken(token string) (cacheData, error) {
 	return cacheData{}, err
 }
 
-func (a *OSIOAuth) resolveByID(userID, token string) (cacheData, error) {
+func (a *OSIOAuth) resolveByID(userID, token string, tokenType TokenType) (cacheData, error) {
 	plainKey := fmt.Sprintf("%s_%s", token, userID)
 	key := cacheKey(plainKey)
-	val, err := a.cache.Get(key, cacheResolverByID(a.RequestTenantLocation, a.RequestTenantToken, a.RequestSrvAccToken, a.RequestSecretLocation, token, userID)).Get()
+	val, err := a.cache.Get(key, cacheResolverByID(a.RequestTenantLocation, a.RequestTenantToken, a.RequestSrvAccToken, a.RequestSecretLocation, token, tokenType, userID)).Get()
 
 	if data, ok := val.(cacheData); ok {
 		return data, err
@@ -167,7 +179,7 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 				return
 			}
 
-			isSerivce, err := a.CheckSrvAccToken(token)
+			tokenType, err := a.RequestTokenType(token)
 			if err != nil {
 				log.Errorf("Invalid token, %v", err)
 				rw.WriteHeader(http.StatusUnauthorized)
@@ -175,16 +187,16 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 			}
 
 			var cached cacheData
-			if isSerivce {
+			if tokenType != UserToken {
 				userID := r.Header.Get(UserIDHeader)
 				if userID == "" {
 					log.Errorf("%s header is missing", UserIDHeader)
 					rw.WriteHeader(http.StatusUnauthorized)
 					return
 				}
-				cached, err = a.resolveByID(userID, token)
+				cached, err = a.resolveByID(userID, token, tokenType)
 			} else {
-				cached, err = a.resolveByToken(token)
+				cached, err = a.resolveByToken(token, tokenType)
 			}
 
 			if err != nil {
@@ -195,7 +207,7 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 
 			r.Header.Set("Target", cached.Location)
 			r.Header.Set("Authorization", "Bearer "+cached.Token)
-			if isSerivce {
+			if tokenType != UserToken {
 				r.Header.Del(UserIDHeader)
 			}
 		} else {

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -51,7 +51,7 @@ func TestBasic(t *testing.T) {
 	srvAccSecret := "secret"
 
 	osio := NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret)
-	osio.CheckSrvAccToken = testSrvAccToken
+	osio.RequestTokenType = testTokenTypeLocator
 	osioServer := createServer(serverOSIORequest(osio))
 	defer osioServer.Close()
 	osioURL := osioServer.Listener.Addr().String()
@@ -68,8 +68,9 @@ func TestBasic(t *testing.T) {
 		req.Header.Set(UserIDHeader, table.userID)
 		res, _ := http.DefaultClient.Do(req)
 		assert.NotNil(t, res)
-		err := res.Header.Get("err")
-		assert.Empty(t, err, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		errMsg := res.Header.Get("err")
+		assert.Empty(t, errMsg, errMsg)
 
 		cluster.Close()
 	}
@@ -107,17 +108,83 @@ func serverTenantRequest(rw http.ResponseWriter, req *http.Request) {
 	if strings.HasSuffix(req.URL.Path, "/tenants/john") {
 		res = `{
 			"data": {
-				"attributes": {
-					"namespaces": [
-						{
-							"name": "john-preview-che",
-							"type": "che",
-							"cluster-url": "http://127.0.0.1:9091/"
-						}
-					]
-				}
+			  "attributes": {
+				"created-at": "2018-03-21T11:28:22.042269Z",
+				"namespaces": [
+				  {
+					"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+					"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+					"cluster-url": "http://127.0.0.1:9091/",
+					"created-at": "2018-03-21T11:28:22.299195Z",
+					"name": "john-preview-stage",
+					"state": "created",
+					"type": "stage",
+					"updated-at": "2018-03-21T11:28:22.299195Z",
+					"version": "2.0.11"
+				  },
+				  {
+					"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+					"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+					"cluster-url": "http://127.0.0.1:9091/",
+					"created-at": "2018-03-21T11:28:22.372172Z",
+					"name": "john-preview-run",
+					"state": "created",
+					"type": "run",
+					"updated-at": "2018-03-21T11:28:22.372172Z",
+					"version": "2.0.11"
+				  },
+				  {
+					"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+					"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+					"cluster-url": "http://127.0.0.1:9091/",
+					"created-at": "2018-03-21T11:28:22.401522Z",
+					"name": "john-preview-jenkins",
+					"state": "created",
+					"type": "jenkins",
+					"updated-at": "2018-03-21T11:28:22.401522Z",
+					"version": "2.0.11"
+				  },
+				  {
+					"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+					"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+					"cluster-url": "http://127.0.0.1:9091/",
+					"created-at": "2018-03-21T11:28:22.413148Z",
+					"name": "john-preview-che",
+					"state": "created",
+					"type": "che",
+					"updated-at": "2018-03-21T11:28:22.413148Z",
+					"version": "2.0.11"
+				  },
+				  {
+					"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+					"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+					"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+					"cluster-url": "http://127.0.0.1:9091/",
+					"created-at": "2018-03-21T11:28:22.421707Z",
+					"name": "john-preview",
+					"state": "created",
+					"type": "user",
+					"updated-at": "2018-03-21T11:28:22.421707Z",
+					"version": "1.0.91"
+				  }
+				]
+			  },
+			  "id": "a25d20d6-4c6d-498c-97d0-cc7f2abcaca6",
+			  "type": "userservices"
 			}
-		}`
+		  }`
+	} else {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	rw.Write([]byte(res))
 }
@@ -181,6 +248,9 @@ func serverClusterRequest(rw http.ResponseWriter, req *http.Request) {
 			},
 			"type": "kubernetes.io/service-account-token"
 		  }`
+	} else {
+		rw.WriteHeader(http.StatusBadRequest)
+		return
 	}
 	rw.Write([]byte(res))
 }
@@ -224,6 +294,6 @@ func startServer(url string, handler func(w http.ResponseWriter, r *http.Request
 	return
 }
 
-func testSrvAccToken(token string) (bool, error) {
-	return true, nil
+func testTokenTypeLocator(token string) (TokenType, error) {
+	return CheToken, nil
 }

--- a/middlewares/osio/secret.go
+++ b/middlewares/osio/secret.go
@@ -36,8 +36,7 @@ func CreateSecretLocator(client *http.Client) SecretLocator {
 
 func (s *secretLocator) GetName(clusterUrl, clusterToken, nsName, nsType string) (string, error) {
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/nvirani-preview-che/serviceaccounts/che
-	// TODO: NT: nsType not used
-	url := fmt.Sprintf("%sapi/v1/namespaces/%s/serviceaccounts/che", clusterUrl, nsName)
+	url := fmt.Sprintf("%sapi/v1/namespaces/%s/serviceaccounts/%s", clusterUrl, nsName, nsType)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err

--- a/middlewares/osio/tenant.go
+++ b/middlewares/osio/tenant.go
@@ -14,14 +14,14 @@ type tenantLocator struct {
 	tenantURL string
 }
 
-func (t *tenantLocator) GetTenant(token string) (namespace, error) {
+func (t *tenantLocator) GetTenant(token string, tokenType TokenType) (namespace, error) {
 	url := fmt.Sprintf("%s/tenant", t.tenantURL)
-	return locateTenant(t.client, url, token)
+	return locateTenant(t.client, url, token, tokenType)
 }
 
-func (t *tenantLocator) GetTenantById(token, userID string) (namespace, error) {
+func (t *tenantLocator) GetTenantById(token string, tokenType TokenType, userID string) (namespace, error) {
 	url := fmt.Sprintf("%s/tenants/%s", t.tenantURL, userID)
-	return locateTenant(t.client, url, token)
+	return locateTenant(t.client, url, token, tokenType)
 }
 
 func CreateTenantLocator(client *http.Client, tenantBaseURL string) TenantLocator {
@@ -46,15 +46,19 @@ type namespace struct {
 	ClusterURL string `json:"cluster-url"`
 }
 
-func getNamespace(resp response) (ns namespace, err error) {
+func getNamespace(resp response, tokenType TokenType) (ns namespace, err error) {
 	if len(resp.Data.Attributes.Namespaces) == 0 {
-		return ns, fmt.Errorf("unable to locate cluster url")
+		return ns, fmt.Errorf("no namespace found")
 	}
-
-	return resp.Data.Attributes.Namespaces[0], nil
+	for _, namespace := range resp.Data.Attributes.Namespaces {
+		if namespace.Type == string(tokenType) {
+			return namespace, nil
+		}
+	}
+	return ns, fmt.Errorf("no namespace matched")
 }
 
-func locateTenant(client *http.Client, url, token string) (ns namespace, err error) {
+func locateTenant(client *http.Client, url, token string, tokenType TokenType) (ns namespace, err error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return ns, err
@@ -71,5 +75,5 @@ func locateTenant(client *http.Client, url, token string) (ns namespace, err err
 	if err != nil {
 		return ns, err
 	}
-	return getNamespace(r)
+	return getNamespace(r, tokenType)
 }

--- a/middlewares/osio/tenant_test.go
+++ b/middlewares/osio/tenant_test.go
@@ -39,7 +39,7 @@ func TestTenantServiceClient(t *testing.T) {
 				"http://"+server.Listener.Addr().String(),
 			)
 
-			ns, err := locator.GetTenant("xxxxx")
+			ns, err := locator.GetTenant("xxxxx", UserToken)
 			url := ns.ClusterURL
 			assert.Equal(t, test.url, url, "expected URL to be equal")
 			if test.err == nil {
@@ -66,7 +66,8 @@ func tenantService200OK(rw http.ResponseWriter, r *http.Request) {
 				"attributes": {
 					"namespaces": [
 						{
-							"name": "che",
+							"name": "john-preview",
+							"type": "user",
 							"cluster-url": "http://www.test.org"
 						}
 					]


### PR DESCRIPTION
Issue fixed GetSecret() gives 404 not found due to always using first_namespace returned from GetTenant().

When call made to `https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com/api/v1/namespaces/nvirani-preview-che` for secret it interns call to `https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/nvirani-preview-stage/serviceaccounts/stage` here using `stage` instead of `che` namespace is wrong and get 404 not found.  This is happening as we are considering very first namespace in getTenat() call [code_link](https://github.com/fabric8-services/fabric8-oso-proxy/blob/master/middlewares/osio/tenant.go#L54).

Fix provided with GetTenant() returns appropriate namespace. To help GetTenant() to determine which namespace to returns a TokenType is provided.  TokenType can be che, user (for user token).

Minor Fix for Issue  - https://github.com/openshiftio/openshift.io/issues/3417