### PR TITLE
Support identity_id query param and adhoc url for che

### DIFF
--- a/middlewares/osio/auth_test.go
+++ b/middlewares/osio/auth_test.go
@@ -1,6 +1,8 @@
 package middlewares
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,4 +24,69 @@ func TestExtracToken(t *testing.T) {
 			t.Errorf("Incorrect token, want:%s, got:%s", table.expectedToken, actualToken)
 		}
 	}
+}
+
+func TestExtractUserID(t *testing.T) {
+	expectedUserID := "john"
+
+	t.Run("UserID as header", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://f8osoproxy.com", nil)
+		req.Header.Set(UserIDHeader, expectedUserID)
+		userID := extractUserID(req)
+		assert.Equal(t, expectedUserID, userID)
+	})
+
+	t.Run("UserID as query param test1", func(t *testing.T) {
+		urlWithParam := fmt.Sprintf("http://f8osoproxy.com/some/path?%s=%s", UserIDParam, expectedUserID)
+		req, _ := http.NewRequest(http.MethodGet, urlWithParam, nil)
+		userID := extractUserID(req)
+		assert.Equal(t, expectedUserID, userID)
+	})
+
+	t.Run("UserID as query param test2", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://f8osoproxy.com", nil)
+		q := req.URL.Query()
+		q.Set(UserIDParam, expectedUserID)
+		req.URL.RawQuery = q.Encode()
+		userID := extractUserID(req)
+		assert.Equal(t, expectedUserID, userID)
+	})
+
+	t.Run("UserID as part of path", func(t *testing.T) {
+		adhocURL := fmt.Sprintf("http://f8osoproxy.com/?%s=%s/some/path", UserIDParam, expectedUserID)
+		req, _ := http.NewRequest(http.MethodGet, adhocURL, nil)
+		userID := extractUserID(req)
+		assert.Equal(t, expectedUserID, userID)
+	})
+}
+
+func TestRemoveUserID(t *testing.T) {
+	userID := "john"
+
+	t.Run("UserID as header", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://f8osoproxy.com", nil)
+		req.Header.Set(UserIDHeader, userID)
+		removeUserID(req)
+		actualUserID := req.Header.Get(UserIDHeader)
+		assert.Empty(t, actualUserID)
+	})
+
+	t.Run("UserID as query param", func(t *testing.T) {
+		urlWithParam := fmt.Sprintf("http://f8osoproxy.com/some/path?%s=%s", UserIDParam, userID)
+		req, _ := http.NewRequest(http.MethodGet, urlWithParam, nil)
+		removeUserID(req)
+		actualUserID := req.URL.Query().Get(UserIDParam)
+		assert.Empty(t, actualUserID)
+	})
+
+	t.Run("UserID as part of path", func(t *testing.T) {
+		path := "/some/path"
+		adhocURL := fmt.Sprintf("http://f8osoproxy.com/?%s=%s%s", UserIDParam, userID, path)
+		req, _ := http.NewRequest(http.MethodGet, adhocURL, nil)
+		removeUserID(req)
+		actualUserID := req.URL.Query().Get(UserIDParam)
+		assert.Empty(t, actualUserID)
+		assert.Equal(t, path, req.URL.Path)
+		assert.Equal(t, path, req.RequestURI)
+	})
 }


### PR DESCRIPTION
Integration between che and oso-proxy needed some temp_fix explained [here](https://github.com/redhat-developer/rh-che/pull/688#issuecomment-393850090).

Now, oso-proxy support all three solution.
sol_no_1: Get UserID from `Impersonate-User` header
sol_no_2: Get UserID from `identity_id` query param
sol_no_3: Get UserID from adhoc URL format

Part of Fixing - https://github.com/openshiftio/openshift.io/issues/3417

