### PR TITLE
rh-che #532: Adding workaround for processing 'exec' urls generated by kubernetes-client

### DIFF
--- a/middlewares/osio/auth.go
+++ b/middlewares/osio/auth.go
@@ -271,6 +271,19 @@ func removeUserID(req *http.Request) {
 		if strings.Contains(userID, "/") {
 			q := req.URL.Query()
 			q.Del(UserIDParam)
+
+			if strings.Contains(userID, "?") {
+				indexOfQuery := strings.Index(userID, "?")
+
+				// adding missing query parameters to request URL query
+				missingQueryParam := userID[indexOfQuery+1:]
+				keyValue := strings.Split(missingQueryParam, "=")
+				q.Add(keyValue[0], keyValue[1])
+
+				// removing query params from userID
+				userID = userID[:indexOfQuery]
+			}
+
 			req.URL.RawQuery = q.Encode()
 			startInd := strings.Index(userID, "/")
 			req.URL.Path = userID[startInd:]


### PR DESCRIPTION
### What does this PR do?

Adding workaround for processing 'exec' urls generated by kubernetes-client.
e.g. 
https://f8osoproxy-test-dsaas-preview.b6ff.rh-idev.openshiftapps.com?identity_id=11111111-1111-1111-1111-11111111/api/v1/namespaces/osio-ci-ee1-preview-che/pods/mypod/exec?command=date&tty=true&stdin=true&stdout=true&stderr=true


### Motivation

Running che workspaces using che sa token - https://github.com/redhat-developer/rh-che/issues/532

### More

- [x] Added/updated tests
- [ ] Added/updated documentation


