### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -13,11 +13,11 @@ fi
 docker build -t f8osoproxy-deploy -f "${DOCKERFILE_DEPLOY}" .
 
 if [ "$TARGET" = "rhel" ]; then
-    tag_push ${REGISTRY}/osio-prod/fabric8-services/fabric8-oso-proxy:$TAG
-    tag_push ${REGISTRY}/osio-prod/fabric8-services/fabric8-oso-proxy:latest
+    tag_push ${REGISTRY}/rhel-fabric8-services-fabric8-oso-proxy:$TAG
+    tag_push ${REGISTRY}/rhel-fabric8-services-fabric8-oso-proxy:latest
 else
-    tag_push ${REGISTRY}/fabric8-services/fabric8-oso-proxy:$TAG
-    tag_push ${REGISTRY}/fabric8-services/fabric8-oso-proxy:latest
+    tag_push ${REGISTRY}/fabric8-services-fabric8-oso-proxy:$TAG
+    tag_push ${REGISTRY}/fabric8-services-fabric8-oso-proxy:latest
 fi
 
 echo 'CICO: Image pushed, ready to update deployed app'

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REGISTRY="push.registry.devshift.net"
+REGISTRY="quay.io"
 
 if [ "$TARGET" = "rhel" ]; then
   DOCKERFILE_DEPLOY="Dockerfile.deploy.rhel"
@@ -18,18 +18,14 @@ function tag_push() {
 # Source environment variables of the jenkins slave
 # that might interest this worker.
 function load_jenkins_vars() {
-  if [ -e "jenkins-env" ]; then
-    cat jenkins-env \
-      | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-      | sed 's/^/export /g' \
-      > ~/.jenkins-env
-    source ~/.jenkins-env
+  if [ -e "jenkins-env.json" ]; then
+    eval "$(./env-toolkit load -f jenkins-env.json DEVSHIFT_TAG_LEN QUAY_USERNAME QUAY_PASSWORD JENKINS_URL GIT_BRANCH GIT_COMMIT BUILD_NUMBER ghprbSourceBranch ghprbActualCommit BUILD_URL ghprbPullId)"
   fi
 }
 
 function login() {
-  if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-    docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${REGISTRY}
+  if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+    docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${REGISTRY}
   else
     echo "Could not login, missing credentials for the registry"
   fi

--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -116,6 +116,6 @@ objects:
       deploymentconfig: f8osoproxy
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/fabric8-oso-proxy
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-oso-proxy
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.

PR: https://github.com/openshiftio/saas-openshiftio/pull/913