### PR TITLE
oso-proxy upgrade with traefik 1.6.4

### DIFF
--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -24,3 +24,4 @@ docker exec -t "$BUILDER-run" bash -ec 'go build -o dist/traefik ./cmd/traefik'
 docker exec -t "$BUILDER-run" bash -ec 'go test -v ./middlewares/osio/'
 docker exec -t "$BUILDER-run" bash -ec 'go test -v ./provider/osio/'
 docker exec -t "$BUILDER-run" bash -ec 'go test -v ./integration/ -integration -osio'
+


### PR DESCRIPTION
Fix - https://github.com/openshiftio/openshift.io/issues/3554

As of now, traefik 1.6.4 latest release is available so this PR upgraded oso-proxy with traefik 1.6.4
