### PR TITLE
Add Metrics, Console, Logs support into oso-proxy

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -408,14 +408,14 @@ func (gc *GlobalConfiguration) initACMEProvider() {
 		if len(saSecret) <= 0 {
 			panic("Missing SERVICE_ACCOUNT_SECRET")
 		}
-		authURL := os.Getenv("AUTH_URL")
-		if len(gc.OSIO.TokenAPI) <= 0 {
-			gc.OSIO.TokenAPI = authURL + "/token"
-		}
-		if len(gc.OSIO.ClusterAPI) <= 0 {
-			gc.OSIO.ClusterAPI = authURL + "/clusters"
-		}
 		gc.OSIO.ServiceAccountSecret = saSecret
+
+		authURL := os.Getenv("AUTH_URL")
+		if len(authURL) <= 0 {
+			panic("Missing AUTH_URL")
+		}
+		gc.OSIO.TokenURL = authURL + "/token"
+		gc.OSIO.ClustersURL = authURL + "/clusters"
 	}
 }
 

--- a/integration/common/osio.go
+++ b/integration/common/osio.go
@@ -23,7 +23,7 @@ var keyID = "test-key"
 
 var TestTokenManager = NewTestTokenManager()
 
-func StartOSIOServer(port int, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
+func StartServer(port int, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
 	if handler == nil {
 		handler = func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, "port=%d", port)
@@ -47,14 +47,18 @@ func ServeTenantRequest(rw http.ResponseWriter, req *http.Request) {
 	jwtToken := TestTokenManager.ToJwtToken(token)
 	sub, _ := jwtToken.Claims.(jwt.MapClaims)["sub"].(string)
 
-	host := ""
+	metricsHost := ""
+	apiHost := ""
 	switch {
 	case strings.HasSuffix(sub, "1111"):
-		host = "http://127.0.0.1:8081"
+		metricsHost = "http://127.0.0.1:7071"
+		apiHost = "http://127.0.0.1:8081"
 	case strings.HasSuffix(sub, "2222"):
-		host = "http://127.0.0.1:8082"
+		metricsHost = "http://127.0.0.1:7072"
+		apiHost = "http://127.0.0.1:8082"
 	case strings.HasSuffix(sub, "3333"):
-		host = "http://127.0.0.1:8083" // :8083 is not present in toml file
+		metricsHost = "http://127.0.0.1:7073"
+		apiHost = "http://127.0.0.1:8083" // :8083 is not present in toml file
 	case strings.HasSuffix(sub, "4444"):
 		rw.WriteHeader(http.StatusNotFound)
 		return
@@ -65,14 +69,15 @@ func ServeTenantRequest(rw http.ResponseWriter, req *http.Request) {
 			"attributes": {
 				"namespaces": [
 					{
-						"name": "john-preview",
+						"name": "myuser-preview",
 						"type": "user",
-						"cluster-url": "%s/"
+						"cluster-metrics-url": "%s",
+						"cluster-url": "%s"
 					}
 				]
 			}
 		}
-	}`, host)
+	}`, metricsHost, apiHost)
 	rw.Write([]byte(res))
 }
 
@@ -101,14 +106,14 @@ func TwoClusterData() string {
 				"api-url": "http://127.0.0.1:8081/",
 				"app-dns": "8a09.starter-us-east-2.openshiftapps.com",
 				"console-url": "https://console.starter-us-east-2.openshift.com/console/",
-				"metrics-url": "https://metrics.starter-us-east-2.openshift.com/",
+				"metrics-url": "http://127.0.0.1:7071/",
 				"name": "us-east-2"
 			},
 			{
 				"api-url": "http://127.0.0.1:8082/",
 				"app-dns": "b542.starter-us-east-2a.openshiftapps.com",
 				"console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-				"metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+				"metrics-url": "http://127.0.0.1:7072/",
 				"name": "us-east-2a"
 			}
 		]
@@ -124,7 +129,7 @@ func OneClusterData() string {
 				"api-url": "http://localhost:8081/",
 				"app-dns": "8a09.starter-us-east-2.openshiftapps.com",
 				"console-url": "https://console.starter-us-east-2.openshift.com/console/",
-				"metrics-url": "https://metrics.starter-us-east-2.openshift.com/",
+				"metrics-url": "http://127.0.0.1:7071/",
 				"name": "us-east-2"
 			}
 		]

--- a/integration/fixtures/osio_middleware_config.toml
+++ b/integration/fixtures/osio_middleware_config.toml
@@ -8,33 +8,65 @@ defaultEntryPoints = ["http"]
 
 checkNewVersion = false
 
+[accessLog]
+format = "json"
+  [accessLog.fields.headers]
+  defaultMode = "keep"
+    [accessLog.fields.names]
+    "RequestLine" = "drop"    
+    [accessLog.fields.headers.names]
+    "Authorization" = "redact"
+
 [api]
 entryPoint = "traefik"
-
-[traefiklog]
-filepath = "traefik.log"
 
 [file]
 watch = false
 
 [Backends]
-  [Backends.backend1]
-    [Backends.backend1.Servers]
-      [Backends.backend1.Servers.server1]
-        URL = "http://127.0.0.1:8081/"
+  [Backends.api1]
+    [Backends.api1.Servers]
+      [Backends.api1.Servers.server1]
+        URL = "http://127.0.0.1:8081"
         Weight = 0
-  [Backends.backend2]
-    [Backends.backend2.Servers]
-      [Backends.backend2.Servers.server1]
-        URL = "http://127.0.0.1:8082/"
+  [Backends.api2]
+    [Backends.api2.Servers]
+      [Backends.api2.Servers.server1]
+        URL = "http://127.0.0.1:8082"
         Weight = 0
   [Backends.default]
     [Backends.default.Servers]
       [Backends.default.Servers.server1]
-        URL = "http://127.0.0.1:8081/"
+        URL = "http://127.0.0.1:8081"
+        Weight = 0
+  [Backends.metrics1]
+    [Backends.metrics1.Servers]
+      [Backends.metrics1.Servers.server1]
+        URL = "http://127.0.0.1:7071"
+        Weight = 0
+  [Backends.metrics2]
+    [Backends.metrics2.Servers]
+      [Backends.metrics2.Servers.server1]
+        URL = "http://127.0.0.1:7072"
         Weight = 0
 
 [Frontends]
+  [Frontends.api1]
+    Backend = "api1"
+    PassHostHeader = false
+    PassTLSCert = false
+    Priority = 0
+    [Frontends.api1.Routes]
+      [Frontends.api1.Routes.test_1]
+        Rule = "Headers:Target,http://127.0.0.1:8081"
+  [Frontends.api2]
+    Backend = "api2"
+    PassHostHeader = false
+    PassTLSCert = false
+    Priority = 0
+    [Frontends.api2.Routes]
+      [Frontends.api2.Routes.test_1]
+        Rule = "Headers:Target,http://127.0.0.1:8082"
   [Frontends.default]
     Backend = "default"
     PassHostHeader = false
@@ -42,20 +74,20 @@ watch = false
     Priority = 0
     [Frontends.default.Routes]
       [Frontends.default.Routes.test_1]
-        Rule = "HeadersRegexp:Target,default"
-  [Frontends.frontend1]
-    Backend = "backend1"
+        Rule = "Headers:Target,default"
+  [Frontends.metrics1]
+    Backend = "metrics1"
     PassHostHeader = false
     PassTLSCert = false
     Priority = 0
-    [Frontends.frontend1.Routes]
-      [Frontends.frontend1.Routes.test_1]
-        Rule = "HeadersRegexp:Target,http://127.0.0.1:8081/"
-  [Frontends.frontend2]
-    Backend = "backend2"
+    [Frontends.metrics1.Routes]
+      [Frontends.metrics1.Routes.test_1]
+        Rule = "Headers:Target,http://127.0.0.1:7071"
+  [Frontends.metrics2]
+    Backend = "metrics2"
     PassHostHeader = false
     PassTLSCert = false
     Priority = 0
-    [Frontends.frontend2.Routes]
-      [Frontends.frontend2.Routes.test_1]
-        Rule = "HeadersRegexp:Target,http://127.0.0.1:8082/"
+    [Frontends.metrics2.Routes]
+      [Frontends.metrics2.Routes.test_1]
+        Rule = "Headers:Target,http://127.0.0.1:7072"

--- a/integration/fixtures/osio_provider_config.toml
+++ b/integration/fixtures/osio_provider_config.toml
@@ -1,4 +1,4 @@
-logLevel = "ERROR"
+logLevel = "DEBUG"
 defaultEntryPoints = ["http"]
 [entryPoints]
   [entryPoints.http]
@@ -8,10 +8,17 @@ defaultEntryPoints = ["http"]
 
 checkNewVersion = false
 
+[accessLog]
+format = "json"
+  [accessLog.fields.headers]
+  defaultMode = "keep"
+    [accessLog.fields.names]
+    "RequestLine" = "drop"    
+    [accessLog.fields.headers.names]
+    "Authorization" = "redact"
+
 [api]
 entryPoint = "traefik"
 
 [osio]
 refreshSeconds = 3
-clusterAPI = "http://127.0.0.1:9091/api/clusters"
-tokenAPI = "http://127.0.0.1:9091/api/token"

--- a/integration/osio_middleware_test.go
+++ b/integration/osio_middleware_test.go
@@ -25,10 +25,16 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	os.Setenv("SERVICE_ACCOUNT_ID", "any-id")
 	os.Setenv("SERVICE_ACCOUNT_SECRET", "anysecret")
 	os.Setenv("AUTH_TOKEN_KEY", "secret")
-	witServer := common.StartOSIOServer(9090, common.ServeTenantRequest)
-	defer witServer.Close()
-	authServer := common.StartOSIOServer(9091, common.ServerAuthRequest(serverMiddlewareCluster))
+	tenantServer := common.StartServer(9090, common.ServeTenantRequest)
+	defer tenantServer.Close()
+	authServer := common.StartServer(9091, common.ServerAuthRequest(serverMiddlewareCluster))
 	defer authServer.Close()
+
+	// Start OSIO servers
+	ts1 := common.StartServer(8081, nil)
+	defer ts1.Close()
+	ts2 := common.StartServer(8082, nil)
+	defer ts2.Close()
 
 	// Start Traefik
 	cmd, display := s.traefikCmd(withConfigFile("fixtures/osio_middleware_config.toml"))
@@ -37,18 +43,12 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	// Start OSIO servers
-	ts1 := common.StartOSIOServer(8081, nil)
-	defer ts1.Close()
-	ts2 := common.StartOSIOServer(8082, nil)
-	defer ts2.Close()
-
 	// Make some requests
 	req, _ := http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "1111"})))
 	res, err := try.Response(req, 500*time.Millisecond)
 	c.Assert(err, check.IsNil)
-	log.Printf("req1 res.StatusCode=%d", res.StatusCode)
+	log.Printf("Test server found, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 200)
 	checkPort(c, res, 8081)
 
@@ -56,7 +56,7 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "2222"})))
 	res, err = try.Response(req, 500*time.Millisecond)
 	c.Assert(err, check.IsNil)
-	log.Printf("req2 res.StatusCode=%d", res.StatusCode)
+	log.Printf("Test server found, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 200)
 	checkPort(c, res, 8082)
 
@@ -64,28 +64,28 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "3333"})))
 	res, err = try.Response(req, 500*time.Millisecond)
 	c.Assert(err, check.IsNil)
-	log.Printf("req3 res.StatusCode=%d", res.StatusCode)
+	log.Printf("Test no server found, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 404)
 
 	req, _ = http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "4444"})))
 	res, err = try.Response(req, 500*time.Millisecond)
 	c.Assert(err, check.IsNil)
-	log.Printf("req4 res.StatusCode=%d", res.StatusCode)
+	log.Printf("Test user not authorized, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 401)
 
 	req, _ = http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
 	// req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "1111"})))
 	res, err = try.Response(req, 500*time.Millisecond)
 	c.Assert(err, check.IsNil)
-	log.Printf("req5 res.StatusCode=%d", res.StatusCode)
+	log.Printf("Test no Authorization found, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 401)
 
 	req, _ = http.NewRequest("OPTIONS", "http://127.0.0.1:8000/test", nil)
 	// req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "1111"})))
 	res, err = try.Response(req, 500*time.Millisecond)
 	c.Assert(err, check.IsNil)
-	log.Printf("req6 res.StatusCode=%d", res.StatusCode)
+	log.Printf("Test default server found for OPTIONS request, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 200)
 	checkPort(c, res, 8081)
 }

--- a/integration/osio_provider_test.go
+++ b/integration/osio_provider_test.go
@@ -23,10 +23,20 @@ func (s *OSIOProviderSuite) TestOSIOProvider(c *check.C) {
 	os.Setenv("SERVICE_ACCOUNT_ID", "any-id")
 	os.Setenv("SERVICE_ACCOUNT_SECRET", "anysecret")
 	os.Setenv("AUTH_TOKEN_KEY", "secret")
-	witServer := common.StartOSIOServer(9090, common.ServeTenantRequest)
-	defer witServer.Close()
-	authServer := common.StartOSIOServer(9091, common.ServerAuthRequest(serveProviderCluster))
+	tenantServer := common.StartServer(9090, common.ServeTenantRequest)
+	defer tenantServer.Close()
+	authServer := common.StartServer(9091, common.ServerAuthRequest(serveProviderCluster))
 	defer authServer.Close()
+
+	// Start OSIO servers
+	ts1 := common.StartServer(8081, nil)
+	defer ts1.Close()
+	ts2 := common.StartServer(8082, nil)
+	defer ts2.Close()
+	ts3 := common.StartServer(7071, nil)
+	defer ts3.Close()
+	ts4 := common.StartServer(7072, nil)
+	defer ts4.Close()
 
 	// Start Traefik
 	cmd, display := s.traefikCmd(withConfigFile("fixtures/osio_provider_config.toml"))
@@ -35,33 +45,48 @@ func (s *OSIOProviderSuite) TestOSIOProvider(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	defer cmd.Process.Kill()
 
-	// Start OSIO servers
-	ts1 := common.StartOSIOServer(8081, nil)
-	defer ts1.Close()
-	ts2 := common.StartOSIOServer(8082, nil)
-	defer ts2.Close()
-
 	// make multiple reqeust on some time gap
-	// note, req has 'Bearer 2222' so it should go to 'http://127.0.0.1:8082' check serverAUTHRequest2()
-	// check serverAUTHRequest2(), return 'http://127.0.0.1:8082' cluster for only first time
+	// note, req has 'Bearer 2222' so it should go to 'http://127.0.0.1:8082' check ServeWITRequest()
+	// check serveProviderCluster(), return 'http://127.0.0.1:8082' cluster for only first time
 	// so first few response would be 'HTTP 200 OK' and then rest would be 'HTTP 404 not found'
 	gotOk := false
 	gotNotFound := false
 	for i := 0; i < 8; i++ {
-		time.Sleep(1 * time.Second)
-		req, _ := http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
+		time.Sleep(1 * time.Second) // need to give time to traefik to load configuration
+
+		url := "http://127.0.0.1:8000/restall"
+		req, _ := http.NewRequest("GET", url, nil)
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "2222"})))
 		res, _ := try.Response(req, 500*time.Millisecond)
-		log.Printf("req res.StatusCode=%d", res.StatusCode)
+		log.Printf("url=%s, res.StatusCode=%d", url, res.StatusCode)
+
 		if res.StatusCode == http.StatusOK {
-			gotOk = true
+			if !gotOk {
+				gotOk = true
+				makeRequest(c, "http://127.0.0.1:8000/api", 200)
+				makeRequest(c, "http://127.0.0.1:8000/api/anything", 200)
+				makeRequest(c, "http://127.0.0.1:8000/metrics", 200)
+				makeRequest(c, "http://127.0.0.1:8000/metrics/anything", 200)
+			}
 		} else if gotOk && res.StatusCode == http.StatusNotFound {
 			gotNotFound = true
+			makeRequest(c, "http://127.0.0.1:8000/api", 404)
+			makeRequest(c, "http://127.0.0.1:8000/api/anything", 404)
+			makeRequest(c, "http://127.0.0.1:8000/metrics", 404)
+			makeRequest(c, "http://127.0.0.1:8000/metrics/anything", 404)
 			break
 		}
 	}
 	c.Assert(gotOk, check.Equals, true)
 	c.Assert(gotNotFound, check.Equals, true)
+}
+
+func makeRequest(c *check.C, url string, expectedStatusCode int) {
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "2222"})))
+	res, _ := try.Response(req, 500*time.Millisecond)
+	log.Printf("url=%s, res.StatusCode=%d", url, res.StatusCode)
+	c.Assert(res.StatusCode, check.Equals, expectedStatusCode)
 }
 
 var oneClusterExists = false

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testCheCtx struct {
+	tables          []testCheData
+	authCallCount   int
+	tenantCallCount int
+	currInd         int
+}
+
 type testCheData struct {
 	inputPath      string
 	userID         string
@@ -19,30 +26,27 @@ type testCheData struct {
 	expectedToken  string
 }
 
-var cheDataTables = []testCheData{
+var cheCtx = testCheCtx{tables: []testCheData{
 	{
 		"/api",
 		"john",
-		"127.0.0.1:9091/",
+		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
 	{
 		"/api",
 		"john",
-		"127.0.0.1:9091/",
+		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
-}
+}}
 
-var currCheTestInd int
-var cheTenantCalls int
-
-func TestBasic(t *testing.T) {
+func TestChe(t *testing.T) {
 	os.Setenv("AUTH_TOKEN_KEY", "foo")
 
-	authServer := createServer(serveAuthRequest)
+	authServer := cheCtx.createServer(cheCtx.serveAuthRequest)
 	defer authServer.Close()
-	tenantServer := createServer(serverTenantRequest)
+	tenantServer := cheCtx.createServer(cheCtx.serveTenantRequest)
 	defer tenantServer.Close()
 
 	authURL := "http://" + authServer.Listener.Addr().String()
@@ -51,14 +55,14 @@ func TestBasic(t *testing.T) {
 	srvAccSecret := "secret"
 
 	osio := NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret)
-	osio.RequestTokenType = testTokenTypeLocator
-	osioServer := createServer(serverOSIORequest(osio))
+	osio.RequestTokenType = cheCtx.testTokenTypeLocator
+	osioServer := cheCtx.createServer(cheCtx.serverOSIORequest(osio))
 	defer osioServer.Close()
 	osioURL := osioServer.Listener.Addr().String()
 
-	for ind, table := range cheDataTables {
-		currCheTestInd = ind
-		cluster := startServer(table.expectedTarget, serverClusterRequest)
+	for ind, table := range cheCtx.tables {
+		cheCtx.currInd = ind
+		cluster := cheCtx.startServer(table.expectedTarget, cheCtx.serveClusterRequest)
 
 		currReqPath := table.inputPath
 		cheSAToken := "1000_che_sa_token"
@@ -75,16 +79,16 @@ func TestBasic(t *testing.T) {
 		cluster.Close()
 	}
 	expecteTenantCalls := 1
-	assert.Equal(t, expecteTenantCalls, cheTenantCalls, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheTenantCalls)
+	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 
-func createServer(handle func(http.ResponseWriter, *http.Request)) *httptest.Server {
+func (t testCheCtx) createServer(handle func(http.ResponseWriter, *http.Request)) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handle)
 	return httptest.NewServer(mux)
 }
 
-func serveAuthRequest(rw http.ResponseWriter, req *http.Request) {
+func (t testCheCtx) serveAuthRequest(rw http.ResponseWriter, req *http.Request) {
 	var res string
 	if strings.HasSuffix(req.URL.Path, "/token") && req.Method == "POST" {
 		res = `{
@@ -102,8 +106,8 @@ func serveAuthRequest(rw http.ResponseWriter, req *http.Request) {
 	rw.Write([]byte(res))
 }
 
-func serverTenantRequest(rw http.ResponseWriter, req *http.Request) {
-	cheTenantCalls++
+func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request) {
+	cheCtx.tenantCallCount++
 	var res string
 	if strings.HasSuffix(req.URL.Path, "/tenants/john") {
 		res = `{
@@ -189,7 +193,7 @@ func serverTenantRequest(rw http.ResponseWriter, req *http.Request) {
 	rw.Write([]byte(res))
 }
 
-func serverClusterRequest(rw http.ResponseWriter, req *http.Request) {
+func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Request) {
 	res := ""
 	if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/serviceaccounts/che") {
 		res = `{
@@ -255,20 +259,20 @@ func serverClusterRequest(rw http.ResponseWriter, req *http.Request) {
 	rw.Write([]byte(res))
 }
 
-func serverOSIORequest(osio *OSIOAuth) func(http.ResponseWriter, *http.Request) {
+func (t testCheCtx) serverOSIORequest(osio *OSIOAuth) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
-		osio.ServeHTTP(rw, req, varifyHandler)
+		osio.ServeHTTP(rw, req, cheCtx.varifyHandler)
 	}
 }
 
-func varifyHandler(rw http.ResponseWriter, req *http.Request) {
-	expectedTarget := cheDataTables[currCheTestInd].expectedTarget
+func (t testCheCtx) varifyHandler(rw http.ResponseWriter, req *http.Request) {
+	expectedTarget := cheCtx.tables[cheCtx.currInd].expectedTarget
 	actualTarget := req.Header.Get("Target")
 	if !strings.HasSuffix(actualTarget, expectedTarget) {
 		rw.Header().Set("err", fmt.Sprintf("Target was incorrect, want:%s, got:%s", expectedTarget, actualTarget))
 		return
 	}
-	expectedToken := cheDataTables[currCheTestInd].expectedToken
+	expectedToken := cheCtx.tables[cheCtx.currInd].expectedToken
 	actualToken := req.Header.Get(Authorization)
 	if !strings.HasSuffix(actualToken, expectedToken) {
 		rw.Header().Set("err", fmt.Sprintf("Token was incorrect, want:%s, got:%s", expectedToken, actualToken))
@@ -281,7 +285,7 @@ func varifyHandler(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func startServer(url string, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
+func (t testCheCtx) startServer(url string, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
 	if listener, err := net.Listen("tcp", strings.Replace(url, "/", "", -1)); err != nil {
 		panic(err)
 	} else {
@@ -294,6 +298,6 @@ func startServer(url string, handler func(w http.ResponseWriter, r *http.Request
 	return
 }
 
-func testTokenTypeLocator(token string) (TokenType, error) {
+func (t testCheCtx) testTokenTypeLocator(token string) (TokenType, error) {
 	return CheToken, nil
 }

--- a/middlewares/osio/osio_redirect_test.go
+++ b/middlewares/osio/osio_redirect_test.go
@@ -1,0 +1,210 @@
+package middlewares
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testRedirectCtx struct {
+	table            []testRedirectData
+	authCallCount    int
+	tenantCallCount  int
+	nextHandlerCount int
+	currInd          int
+}
+
+type testRedirectData struct {
+	inputPath    string
+	osioToken    string
+	expectedHost string
+	expectedURL  string
+}
+
+var redirectCtx = testRedirectCtx{table: []testRedirectData{
+	{
+		"/console/project/john-preview",
+		"1000",
+		"localhost:9090",
+		"/console/project/john-preview",
+	},
+	{
+		"/console/project/sara-preview",
+		"2000",
+		"localhost:9091",
+		"/console/project/sara-preview",
+	},
+	{
+		"/logs/project/john-preview?tab=logs",
+		"1000",
+		"localhost:9090",
+		"/console/project/john-preview?tab=logs",
+	},
+	{
+		"/logs/project/sara-preview",
+		"2000",
+		"localhost:9091",
+		"/console/project/sara-preview",
+	},
+}}
+
+func TestRedirect(t *testing.T) {
+	os.Setenv("AUTH_TOKEN_KEY", "foo")
+
+	authServer := redirectCtx.createServer(redirectCtx.serveAuthRequest)
+	defer authServer.Close()
+	tenantServer := redirectCtx.createServer(redirectCtx.serverTenantRequest)
+	defer tenantServer.Close()
+
+	authURL := "http://" + authServer.Listener.Addr().String()
+	tenantURL := "http://" + tenantServer.Listener.Addr().String()
+	srvAccID := "sa1"
+	srvAccSecret := "secret"
+
+	osio := NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret)
+	osio.RequestTokenType = redirectCtx.testTokenTypeLocator
+	osioServer := redirectCtx.createServer(redirectCtx.serveOSIORequest(osio))
+	defer osioServer.Close()
+	osioURL := osioServer.Listener.Addr().String()
+
+	osoServer1 := redirectCtx.createServerAtPort(9090, redirectCtx.serveOSORequest)
+	defer osoServer1.Close()
+	osoServer2 := redirectCtx.createServerAtPort(9091, redirectCtx.serveOSORequest)
+	defer osoServer2.Close()
+
+	for ind, table := range redirectCtx.table {
+		redirectCtx.currInd = ind
+		currReqPath := table.inputPath
+		currOsioToken := table.osioToken
+
+		req, _ := http.NewRequest("GET", "http://"+osioURL+currReqPath, nil)
+		req.Header.Set("Authorization", "Bearer "+currOsioToken)
+		res, _ := http.DefaultClient.Do(req)
+		assert.NotNil(t, res)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		assert.NotNil(t, res.Body)
+		defer res.Body.Close()
+		body, err := ioutil.ReadAll(res.Body)
+		assert.Nil(t, err)
+		actualBody := string(body)
+		assert.Empty(t, actualBody, actualBody)
+	}
+
+	expecteTenantCalls := 2
+	assert.Equal(t, expecteTenantCalls, redirectCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, redirectCtx.tenantCallCount)
+	expecteAuthCalls := 2
+	assert.Equal(t, expecteAuthCalls, redirectCtx.authCallCount, "Number of time Auth server called was incorrect, want:%d, got:%d", expecteAuthCalls, redirectCtx.authCallCount)
+	expecteNextHandlerCalls := 0
+	assert.Equal(t, expecteNextHandlerCalls, redirectCtx.nextHandlerCount, "Number of time Next handler called was incorrect, want:%d, got:%d", expecteNextHandlerCalls, redirectCtx.nextHandlerCount)
+}
+
+func (t testRedirectCtx) createServer(handle func(http.ResponseWriter, *http.Request)) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handle)
+	return httptest.NewServer(mux)
+}
+
+func (t testRedirectCtx) createServerAtPort(port int, handler func(w http.ResponseWriter, r *http.Request)) (ts *httptest.Server) {
+	if handler == nil {
+		handler = func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "port=%d", port)
+		}
+	}
+	if listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port)); err != nil {
+		panic(err)
+	} else {
+		ts = &httptest.Server{
+			Listener: listener,
+			Config:   &http.Server{Handler: http.HandlerFunc(handler)},
+		}
+		ts.Start()
+	}
+	return
+}
+
+func (t testRedirectCtx) serverTenantRequest(rw http.ResponseWriter, req *http.Request) {
+	redirectCtx.tenantCallCount++
+
+	user := ""
+	consoleURL := ""
+	authHeader := req.Header.Get("Authorization")
+
+	switch {
+	case strings.HasSuffix(authHeader, "1000"):
+		user = "1000"
+		consoleURL = "http://localhost:9090/console"
+	case strings.HasSuffix(authHeader, "2000"):
+		user = "2000"
+		consoleURL = "http://localhost:9091/console/"
+	}
+
+	res := fmt.Sprintf(`{
+		"data": {
+			"attributes": {
+				"namespaces": [
+					{
+						"name": "myuser%s-preview-stage",
+						"type": "user",
+						"cluster-console-url": "%s",
+						"cluster-logging-url": "%s"
+					}
+				]
+			}
+		}
+	}`, user, consoleURL, consoleURL)
+	rw.Write([]byte(res))
+}
+
+func (t testRedirectCtx) serveAuthRequest(rw http.ResponseWriter, req *http.Request) {
+	redirectCtx.authCallCount++
+
+	token := "1001"
+	if strings.HasSuffix(req.Header.Get(Authorization), "1000") {
+		token = "1001"
+	} else if strings.HasSuffix(req.Header.Get(Authorization), "2000") {
+		token = "2001"
+	}
+	res := fmt.Sprintf(`{"token_type":"bearer", "scope":"user","access_token":"%s"}`, token)
+	rw.Write([]byte(res))
+}
+
+func (t testRedirectCtx) serveOSIORequest(osio *OSIOAuth) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		osio.ServeHTTP(rw, req, nopHandler)
+	}
+}
+
+func (t testRedirectCtx) serveOSORequest(rw http.ResponseWriter, req *http.Request) {
+	expectedHost := redirectCtx.table[redirectCtx.currInd].expectedHost
+	actualHost := req.Host
+	if expectedHost != actualHost {
+		err := fmt.Sprintf("Host was incorrect, want:%s, got:%s", expectedHost, actualHost)
+		rw.Write([]byte(err))
+		return
+	}
+	expectedURL := redirectCtx.table[redirectCtx.currInd].expectedURL
+	actualURL := req.URL.Path
+	if req.URL.RawQuery != "" {
+		actualURL = actualURL + "?" + req.URL.RawQuery
+	}
+	if expectedURL != actualURL {
+		err := fmt.Sprintf("URL was incorrect, want:%s, got:%s", expectedURL, actualURL)
+		rw.Write([]byte(err))
+		return
+	}
+}
+
+func (t testRedirectCtx) testTokenTypeLocator(token string) (TokenType, error) {
+	return UserToken, nil
+}
+
+func nopHandler(rw http.ResponseWriter, req *http.Request) {
+	redirectCtx.nextHandlerCount++
+}

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -1,0 +1,208 @@
+package middlewares
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testMiddlewareCtx struct {
+	tables          []testMiddlewareData
+	authCallCount   int
+	tenantCallCount int
+	currInd         int
+}
+
+type testMiddlewareData struct {
+	inputPath      string
+	inputAuth      string
+	expectedTarget string
+	expectedAuth   string
+	expectedPath   string
+}
+
+var mwCtx = testMiddlewareCtx{tables: []testMiddlewareData{
+	{
+		"/",
+		"Bearer 1000",
+		"http://api.cluster1.com",
+		"Bearer 1001",
+		"/",
+	},
+	{
+		"/api",
+		"Bearer 1000",
+		"http://api.cluster1.com",
+		"Bearer 1001",
+		"/",
+	},
+	{
+		"/api/anything",
+		"Bearer 1000",
+		"http://api.cluster1.com",
+		"Bearer 1001",
+		"/anything",
+	},
+	{
+		"/metrics",
+		"Bearer 1000",
+		"http://metrics.cluster1.com",
+		"Bearer 1001",
+		"/",
+	},
+	{
+		"/metrics/anything",
+		"Bearer 1000",
+		"http://metrics.cluster1.com",
+		"Bearer 1001",
+		"/anything",
+	},
+	{
+		"/restall",
+		"Bearer 1000",
+		"http://api.cluster1.com",
+		"Bearer 1001",
+		"/restall",
+	},
+	{
+		"/api",
+		"Bearer 2000",
+		"http://api.cluster1.com",
+		"Bearer 2001",
+		"/",
+	},
+	{
+		"/metrics",
+		"Bearer 2000",
+		"http://metrics.cluster1.com",
+		"Bearer 2001",
+		"/",
+	},
+}}
+
+func TestMiddleware(t *testing.T) {
+	os.Setenv("AUTH_TOKEN_KEY", "foo")
+
+	tenantServer := mwCtx.createServer(mwCtx.serveTenantRequest)
+	defer tenantServer.Close()
+	authServer := mwCtx.createServer(mwCtx.serverAuthRequest)
+	defer authServer.Close()
+
+	tenantURL := "http://" + tenantServer.Listener.Addr().String() + "/"
+	authURL := "http://" + authServer.Listener.Addr().String() + "/"
+	srvAccID := "sa1"
+	srvAccSecret := "secret"
+
+	osio := NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret)
+	osio.RequestTokenType = mwCtx.testTokenTypeLocator
+	osioServer := mwCtx.createServer(mwCtx.serverOSIORequest(osio))
+	osioURL := osioServer.Listener.Addr().String()
+
+	for ind, table := range mwCtx.tables {
+		mwCtx.currInd = ind
+
+		currReqPath := table.inputPath
+		currAuth := table.inputAuth
+
+		req, _ := http.NewRequest("GET", "http://"+osioURL+currReqPath, nil)
+		req.Header.Set("Authorization", currAuth)
+		res, _ := http.DefaultClient.Do(req)
+		assert.NotNil(t, res)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		errMsg := res.Header.Get("err")
+		assert.Empty(t, errMsg, errMsg)
+	}
+
+	// validate cache is used
+	expectedTenantCalls := 2
+	expectedAuthCalls := 2
+	assert.Equal(t, expectedTenantCalls, mwCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expectedTenantCalls, mwCtx.tenantCallCount)
+	assert.Equal(t, expectedAuthCalls, mwCtx.authCallCount, "Number of time Auth server called was incorrect, want:%d, got:%d", expectedAuthCalls, mwCtx.authCallCount)
+}
+
+func (t testMiddlewareCtx) createServer(handle func(http.ResponseWriter, *http.Request)) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handle)
+	return httptest.NewServer(mux)
+}
+
+func (t testMiddlewareCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request) {
+	mwCtx.tenantCallCount++
+	user := ""
+	if strings.HasSuffix(req.Header.Get(Authorization), "1000") {
+		user = "1000"
+	} else if strings.HasSuffix(req.Header.Get(Authorization), "2000") {
+		user = "2000"
+	}
+	res := fmt.Sprintf(`{
+		"data": {
+			"attributes": {
+				"namespaces": [
+					{
+						"name": "myuser%s-preview-stage",
+						"type": "user",
+						"cluster-metrics-url": "http://metrics.cluster1.com",
+						"cluster-url": "http://api.cluster1.com"
+					}
+				]
+			}
+		}
+	}`, user)
+	rw.Write([]byte(res))
+}
+
+func (t testMiddlewareCtx) serverAuthRequest(rw http.ResponseWriter, req *http.Request) {
+	mwCtx.authCallCount++
+	token := "1001"
+	if strings.HasSuffix(req.Header.Get(Authorization), "1000") {
+		token = "1001"
+	} else if strings.HasSuffix(req.Header.Get(Authorization), "2000") {
+		token = "2001"
+	}
+	res := fmt.Sprintf(`{"token_type":"bearer", "scope":"user","access_token":"%s"}`, token)
+	rw.Write([]byte(res))
+}
+
+func (t testMiddlewareCtx) serverOSIORequest(osio *OSIOAuth) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		osio.ServeHTTP(rw, req, mwCtx.varifyHandler)
+	}
+}
+
+func (t testMiddlewareCtx) varifyHandler(rw http.ResponseWriter, req *http.Request) {
+	expectedTarget := mwCtx.tables[mwCtx.currInd].expectedTarget
+	actualTarget := req.Header.Get("Target")
+	if expectedTarget != actualTarget {
+		rw.Header().Set("err", fmt.Sprintf("Target was incorrect, want:%s, got:%s", expectedTarget, actualTarget))
+		return
+	}
+
+	expectedAuth := mwCtx.tables[mwCtx.currInd].expectedAuth
+	actualAuth := req.Header.Get(Authorization)
+	if expectedAuth != actualAuth {
+		rw.Header().Set("err", fmt.Sprintf("Authorization was incorrect, want:%s, got:%s", expectedAuth, actualAuth))
+		return
+	}
+
+	expectedPath := mwCtx.tables[mwCtx.currInd].expectedPath
+	actualPath := req.URL.Path
+	if expectedPath != actualPath {
+		rw.Header().Set("err", fmt.Sprintf("Path was incorrect, want:%s, got:%s", expectedPath, actualPath))
+		return
+	}
+
+	actualPath = req.RequestURI
+	if expectedPath != actualPath {
+		rw.Header().Set("err", fmt.Sprintf("Path was incorrect, want:%s, got:%s", expectedPath, actualPath))
+		return
+	}
+}
+
+func (t testMiddlewareCtx) testTokenTypeLocator(token string) (TokenType, error) {
+	return UserToken, nil
+}

--- a/middlewares/osio/secret.go
+++ b/middlewares/osio/secret.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 )
 
-// TODO: NT: ask response format
 type secretNameResponse struct {
 	SecretNames []secretName `json:"secrets"`
 }
@@ -34,9 +33,10 @@ func CreateSecretLocator(client *http.Client) SecretLocator {
 	return &secretLocator{client: client}
 }
 
-func (s *secretLocator) GetName(clusterUrl, clusterToken, nsName, nsType string) (string, error) {
-	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/nvirani-preview-che/serviceaccounts/che
-	url := fmt.Sprintf("%sapi/v1/namespaces/%s/serviceaccounts/%s", clusterUrl, nsName, nsType)
+func (s *secretLocator) GetName(clusterURL, clusterToken, nsName, nsType string) (string, error) {
+	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/john-preview-che/serviceaccounts/che
+	clusterURL = normalizeURL(clusterURL)
+	url := fmt.Sprintf("%s/api/v1/namespaces/%s/serviceaccounts/%s", clusterURL, nsName, nsType)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -56,9 +56,10 @@ func (s *secretLocator) GetName(clusterUrl, clusterToken, nsName, nsType string)
 	return getSecretName(r)
 }
 
-func (s *secretLocator) GetSecret(clusterUrl, clusterToken, nsName, secretName string) (string, error) {
-	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/nvirani-preview-che/secrets/che-token-w6h6f
-	url := fmt.Sprintf("%sapi/v1/namespaces/%s/secrets/%s", clusterUrl, nsName, secretName)
+func (s *secretLocator) GetSecret(clusterURL, clusterToken, nsName, secretName string) (string, error) {
+	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/john-preview-che/secrets/che-token-xxxx
+	clusterURL = normalizeURL(clusterURL)
+	url := fmt.Sprintf("%s/api/v1/namespaces/%s/secrets/%s", clusterURL, nsName, secretName)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err

--- a/middlewares/osio/tenant.go
+++ b/middlewares/osio/tenant.go
@@ -41,9 +41,12 @@ type attributes struct {
 }
 
 type namespace struct {
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	ClusterURL string `json:"cluster-url"`
+	Name              string `json:"name"`
+	Type              string `json:"type"`
+	ClusterURL        string `json:"cluster-url"`
+	ClusterMetricsURL string `json:"cluster-metrics-url,omitempty"`
+	ClusterConsoleURL string `json:"cluster-console-url,omitempty"`
+	ClusterLoggingURL string `json:"cluster-logging-url,omitempty"`
 }
 
 func getNamespace(resp response, tokenType TokenType) (ns namespace, err error) {

--- a/middlewares/osio/token.go
+++ b/middlewares/osio/token.go
@@ -30,6 +30,7 @@ func (t *tenantTokenLocator) GetTokenWithUserToken(userToken, location string) (
 }
 
 func (t *tenantTokenLocator) GetTokenWithSAToken(saToken, location string) (string, error) {
+	// TODO this clusterToken can be cached in sync with osio.provider
 	encryptedClusterToken, err := locateToken(t.client, t.authBaseURL, saToken, location)
 	if err != nil {
 		return "", err
@@ -50,7 +51,7 @@ func CreateSrvAccTokenLocator(authBaseURL, srvAccID, srvAccSecret string) SrvAcc
 		if saToken != "" {
 			return saToken, nil
 		}
-		res, err := client.CallTokenAPI(authBaseURL+"/token", tokenReq)
+		res, err := client.GetToken(authBaseURL+"/token", tokenReq)
 		if err != nil {
 			return "", err
 		}

--- a/provider/osio/client.go
+++ b/provider/osio/client.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Client interface {
-	CallTokenAPI(tokenAPI string, tokenReq *TokenRequest) (*TokenResponse, error)
-	CallClusterAPI(clusterAPIURL string, tokenResp *TokenResponse) (*clusterResponse, error)
+	GetToken(tokenURL string, tokenReq *TokenRequest) (*TokenResponse, error)
+	GetClusters(clustersURL string, tokenResp *TokenResponse) (*clusterResponse, error)
 }
 
 func NewClient() Client {
@@ -45,7 +45,7 @@ type clusterResponse struct {
 	Clusters []clusterData `json:"data"`
 }
 
-func (client *authClient) CallTokenAPI(tokenAPI string, tokenReq *TokenRequest) (*TokenResponse, error) {
+func (client *authClient) GetToken(tokenAPI string, tokenReq *TokenRequest) (*TokenResponse, error) {
 	reqBody := new(bytes.Buffer)
 	err := json.NewEncoder(reqBody).Encode(tokenReq)
 	if err != nil {
@@ -60,7 +60,7 @@ func (client *authClient) CallTokenAPI(tokenAPI string, tokenReq *TokenRequest) 
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Call to token api failed, code:%d, error:%s", resp.StatusCode, resp.Status)
+		return nil, fmt.Errorf("Failed to get Token, code:%d, error:%s", resp.StatusCode, resp.Status)
 	}
 
 	defer resp.Body.Close()
@@ -72,8 +72,8 @@ func (client *authClient) CallTokenAPI(tokenAPI string, tokenReq *TokenRequest) 
 	return tokenResp, nil
 }
 
-func (client *authClient) CallClusterAPI(clusterAPIURL string, tokenResp *TokenResponse) (*clusterResponse, error) {
-	req, err := http.NewRequest(http.MethodGet, clusterAPIURL, nil)
+func (client *authClient) GetClusters(clustersURL string, tokenResp *TokenResponse) (*clusterResponse, error) {
+	req, err := http.NewRequest(http.MethodGet, clustersURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (client *authClient) CallClusterAPI(clusterAPIURL string, tokenResp *TokenR
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Cluster API call failed with code:%d, error:%s", resp.StatusCode, resp.Status)
+		return nil, fmt.Errorf("Failed to get Clusters details, code:%d, error:%s", resp.StatusCode, resp.Status)
 	}
 
 	defer resp.Body.Close()

--- a/provider/osio/osio.go
+++ b/provider/osio/osio.go
@@ -20,12 +20,6 @@ const (
 	authorization = "Authorization"
 )
 
-// list of cluster hard coded to be filtered out when choosing default backend
-var filterDefaultBackends = map[string]bool{
-	"https://api.starter-us-east-1a.openshift.com": true,
-	"https://api.starter-us-east-1b.openshift.com": true,
-}
-
 // Provider holds configurations of the provider.
 type Provider struct {
 	provider.BaseProvider `mapstructure:",squash" export:"true"`
@@ -33,8 +27,8 @@ type Provider struct {
 	RefreshSeconds       int    `description:"Polling interval (in seconds)" export:"true"`
 	ServiceAccountID     string `description:"Service Account ID" export:"true"`
 	ServiceAccountSecret string `description:"Service Account Secret" export:"true"`
-	TokenAPI             string `description:"Auth token API" export:"true"`
-	ClusterAPI           string `description:"Cluster data API" export:"true"`
+	TokenURL             string `description:"Auth Token URL" export:"true"`
+	ClustersURL          string `description:"Clusters details URL" export:"true"`
 
 	client            Client
 	tokenResp         *TokenResponse
@@ -127,7 +121,7 @@ func (p *Provider) fetchToken() error {
 		return nil
 	}
 	tokenReq := &TokenRequest{GrantType: "client_credentials", ClientID: p.ServiceAccountID, ClientSecret: p.ServiceAccountSecret}
-	tokenResp, err := p.client.CallTokenAPI(p.TokenAPI, tokenReq)
+	tokenResp, err := p.client.GetToken(p.TokenURL, tokenReq)
 	if err != nil {
 		return err
 	}
@@ -136,7 +130,7 @@ func (p *Provider) fetchToken() error {
 }
 
 func (p *Provider) loadConfig() (*types.Configuration, error) {
-	clusterResponse, err := p.client.CallClusterAPI(p.ClusterAPI, p.tokenResp)
+	clusterResponse, err := p.client.GetClusters(p.ClustersURL, p.tokenResp)
 	if err != nil {
 		return nil, err
 	}
@@ -154,15 +148,23 @@ func (p *Provider) loadRules(clusterResp *clusterResponse) *types.Configuration 
 
 	defaultBackendExist := false
 	for ind, cluster := range clusterResp.Clusters {
-		if p.defaultBackendURL != "" && p.defaultBackendURL == cluster.APIURL {
+		if p.defaultBackendURL != "" && p.defaultBackendURL == getDefaultURL(cluster) {
 			defaultBackendExist = true
 		}
 		configInd := fmt.Sprintf("%d", ind+1)
-		config.Frontends["frontend"+configInd] = createFrontend(cluster.APIURL, "backend"+configInd)
-		config.Backends["backend"+configInd] = createBackend(cluster.APIURL)
+		if cluster.APIURL != "" {
+			config.Frontends["api"+configInd] = createFrontend(cluster.APIURL, "api"+configInd)
+			config.Backends["api"+configInd] = createBackend(cluster.APIURL)
+		}
+		if cluster.MetricsURL != "" {
+			config.Frontends["metrics"+configInd] = createFrontend(cluster.MetricsURL, "metrics"+configInd)
+			config.Backends["metrics"+configInd] = createBackend(cluster.MetricsURL)
+		}
 	}
 	if !defaultBackendExist {
-		p.defaultBackendURL = findDefaultURL(clusterResp.Clusters)
+		if len(clusterResp.Clusters) > 0 {
+			p.defaultBackendURL = getDefaultURL(clusterResp.Clusters[0])
+		}
 	}
 	if p.defaultBackendURL != "" {
 		config.Frontends["default"] = createFrontend("default", "default")
@@ -173,30 +175,23 @@ func (p *Provider) loadRules(clusterResp *clusterResponse) *types.Configuration 
 }
 
 func createFrontend(clusterURL string, backend string) *types.Frontend {
+	clusterURL = normalizeURL(clusterURL)
 	routes := make(map[string]types.Route)
-	routes["test_1"] = types.Route{Rule: "HeadersRegexp:Target," + clusterURL}
+	routes["test_1"] = types.Route{Rule: "Headers:Target," + clusterURL}
 	return &types.Frontend{Backend: backend, Routes: routes}
 }
 
 func createBackend(clusterURL string) *types.Backend {
+	clusterURL = normalizeURL(clusterURL)
 	servers := make(map[string]types.Server)
 	servers["server1"] = types.Server{URL: clusterURL}
 	return &types.Backend{Servers: servers}
 }
 
-func findDefaultURL(clusters []clusterData) string {
-	for _, cluster := range clusters {
-		clusterURL := cluster.APIURL
-		found := false
-		for backend := range filterDefaultBackends {
-			if strings.HasPrefix(clusterURL, backend) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return clusterURL
-		}
-	}
-	return ""
+func normalizeURL(url string) string {
+	return strings.TrimSuffix(url, "/")
+}
+
+func getDefaultURL(cluster clusterData) string {
+	return cluster.APIURL
 }


### PR DESCRIPTION
### What does this PR do?
Support metrics, console, logs URL along with API URL in OSO proxy.  Now, metrics URL also dynamically configured with traefik by OSIO provider. 

When any request arrived to OSO proxy
- if its api, metrics request then it will forward to api or metrics cluster
- if its console, logs request then it will redirect request to console cluster 

Fix - https://github.com/openshiftio/openshift.io/issues/2342

### Motivation
Direction towards removing all direct OSO call from OSIO UI.

### More
OSIO provider integration test enhance to consider metrics url.
New component test added which test OSIO middleware without traefik.