### PR TITLE
rh-che #1075: Removing 'Impersonate-Group' header if it is passed from rh-che

### DIFF
--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	Authorization = "Authorization"
+	ImpersonateGroupHeader = "Impersonate-Group"
 	UserIDHeader  = "Impersonate-User"
 	UserIDParam   = "identity_id"
 )
@@ -380,6 +381,11 @@ func extractUserID(req *http.Request) string {
 func removeUserID(req *http.Request) {
 	if req.Header.Get(UserIDHeader) != "" {
 		req.Header.Del(UserIDHeader)
+	}
+	// hot-fix for https://github.com/fabric8io/kubernetes-client/issues/1266
+	// Should be removed once kubernetes-client 4.1.1 is released and che / rh-che will be updated to use this version of kubernetes-client
+	if req.Header.Get(ImpersonateGroupHeader) != "" {
+		req.Header.Del(ImpersonateGroupHeader)
 	}
 	userID := req.URL.Query().Get(UserIDParam)
 	if userID != "" {

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -77,6 +77,7 @@ func TestExtractUserID(t *testing.T) {
 
 func TestRemoveUserID(t *testing.T) {
 	userID := "11111111-1111-1111-1111-11111111"
+	impersonateGroup := "dummyGroup"
 
 	t.Run("UserID as header", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "http://f8osoproxy.com", nil)
@@ -84,6 +85,19 @@ func TestRemoveUserID(t *testing.T) {
 		removeUserID(req)
 		actualUserID := req.Header.Get(UserIDHeader)
 		assert.Empty(t, actualUserID)
+		assert.Equal(t, "http://f8osoproxy.com", req.URL.String())
+	})
+
+	// See https://github.com/fabric8-services/fabric8-oso-proxy/pull/43
+	t.Run("UserID as header with 'Impersonate-Group'", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://f8osoproxy.com", nil)
+		req.Header.Set(UserIDHeader, userID)
+		req.Header.Set(ImpersonateGroupHeader, impersonateGroup)
+		removeUserID(req)
+		actualUserID := req.Header.Get(UserIDHeader)
+		actualImpersonateGroup := req.Header.Get(ImpersonateGroupHeader);
+		assert.Empty(t, actualUserID)
+		assert.Empty(t, actualImpersonateGroup)
 		assert.Equal(t, "http://f8osoproxy.com", req.URL.String())
 	})
 


### PR DESCRIPTION
### What does this PR do?

Removing 'Impersonate-Group' header if it is passed from rh-che

### Motivation

hot-fix related to the issue introduced in kubernetes-client version 4.1.0 - https://github.com/fabric8io/kubernetes-client/issues/1266

This problem has been workaround on rh-che side by adding  `"dummyGroup"` as `Impersonate-Header` - https://github.com/redhat-developer/rh-che/pull/1080

This header should be removed on oso-proxy side when real communication with oso-cluster happens in order to prevent errors like:

> Message: Internal Server Error: \"/apis/project.openshift.io/v1/projects/workspaceuvhpwlzwxd233x00\": requested [{Group  dummyGroup    }] without impersonating a user."

