### PR TITLE
fix: use epel-testing repository to install golang package

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -25,9 +25,9 @@ RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && tar -C /usr/local -xzf go1.10.4.linux-amd64.tar.gz \
     && rm -f go1.10.4.linux-amd64.tar.gz; \
     fi
-ENV PATH=$PATH:/usr/local/go/bin
 ENV GOPATH=/tmp/go
-RUN mkdir -p ${GOPATH}
+RUN mkdir -p ${GOPATH}/bin
 RUN chmod -R a+rwx ${GOPATH}
+ENV PATH=$PATH:/usr/local/go/bin:${GOPATH}/bin
 
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,8 +1,6 @@
 FROM centos:7
 MAINTAINER "Aslak Knutsen <aslak@redhat.com>"
 ENV LANG=en_US.utf8
-ENV GOROOT=/tmp/go1.10
-ENV PATH=$PATH:/tmp/go/bin:$GOROOT/bin
 
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum install epel-release --enablerepo=extras -y \
@@ -20,13 +18,16 @@ RUN yum install epel-release --enablerepo=extras -y \
     && yum clean all \
     && rm -rf /var/cache/yum
 
-# Get custom go v
 RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && wget https://storage.googleapis.com/golang/go1.10.4.linux-amd64.tar.gz  \
     && echo "fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec go1.10.4.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
-    && tar xvzf go*.tar.gz \
-    && mv go $GOROOT; \
+    && tar -C /usr/local -xzf go1.10.4.linux-amd64.tar.gz \
+    && rm -f go1.10.4.linux-amd64.tar.gz; \
     fi
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GOPATH=/tmp/go
+RUN mkdir -p ${GOPATH}
+RUN chmod -R a+rwx ${GOPATH}
 
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,8 @@ ENV GOROOT=/tmp/go1.10
 ENV PATH=$PATH:/tmp/go/bin:$GOROOT/bin
 
 # Some packages might seem weird but they are required by the RVM installer.
-RUN yum --enablerepo=centosplus install -y \
+RUN yum install epel-release --enablerepo=extras -y \
+    && yum --enablerepo=centosplus --enablerepo=epel-testing install -y \
       findutils \
       git \
       make \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -9,6 +9,7 @@ RUN yum install epel-release --enablerepo=extras -y \
     && yum --enablerepo=centosplus --enablerepo=epel-testing install -y \
       findutils \
       git \
+      $(test "$USE_GO_VERSION_FROM_WEBSITE" != 1 && echo "golang") \
       make \
       mercurial \
       procps-ng \
@@ -20,11 +21,12 @@ RUN yum install epel-release --enablerepo=extras -y \
     && rm -rf /var/cache/yum
 
 # Get custom go v
-RUN cd /tmp \
+RUN if [[ "$USE_GO_VERSION_FROM_WEBSITE" = 1 ]]; then cd /tmp \
     && wget https://storage.googleapis.com/golang/go1.10.4.linux-amd64.tar.gz  \
     && echo "fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec go1.10.4.linux-amd64.tar.gz" > checksum \
     && sha256sum -c checksum \
     && tar xvzf go*.tar.gz \
-    && mv go $GOROOT
+    && mv go $GOROOT; \
+    fi
 
 ENTRYPOINT ["/bin/bash"]

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -22,9 +22,9 @@ docker exec -t "$BUILDER-run" bash -ec 'go get github.com/jteeuwen/go-bindata/..
 docker exec -t "$BUILDER-run" bash -ec 'go generate'
 docker exec -t "$BUILDER-run" bash -ec 'go build -o dist/traefik ./cmd/traefik'
 
-docker exec -t "$BUILDER-run" bash -ec 'go test -v ./middlewares/osio/ -coverprofile coverage.middlewares -covermode=set -coverpkg github.com/containous/traefik/middlewares/osio,github.com/containous/traefik/provider/osio -timeout 5m'
-docker exec -t "$BUILDER-run" bash -ec 'go test -v ./provider/osio/ -coverprofile coverage.provider -covermode=set -coverpkg github.com/containous/traefik/middlewares/osio,github.com/containous/traefik/provider/osio -timeout 5m'
-docker exec -t "$BUILDER-run" bash -ec 'go test -v ./integration/ -integration -osio'
+docker exec -t "$BUILDER-run" bash -ec 'go test -v -vet off ./middlewares/osio/ -coverprofile coverage.middlewares -covermode=set -coverpkg github.com/containous/traefik/middlewares/osio,github.com/containous/traefik/provider/osio -timeout 5m'
+docker exec -t "$BUILDER-run" bash -ec 'go test -v -vet off ./provider/osio/ -coverprofile coverage.provider -covermode=set -coverpkg github.com/containous/traefik/middlewares/osio,github.com/containous/traefik/provider/osio -timeout 5m'
+docker exec -t "$BUILDER-run" bash -ec 'go test -v -vet off ./integration/ -integration -osio'
 
 # Upload coverage to codecov.io
 # -t <upload_token> copy from https://codecov.io/gh/fabric8-services/fabric8-oso-proxy/settings

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -15,6 +15,7 @@ docker run --detach=true -t \
     -v $(pwd):$PACKAGE_PATH:Z \
     -u $(id -u $USER):$(id -g $USER) \
     -e GOPATH=$GOPATH_IN_CONTAINER \
+    -e USE_GO_VERSION_FROM_WEBSITE=1 \
     -w $PACKAGE_PATH \
     $BUILDER
 

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -7,7 +7,6 @@ PACKAGE_NAME="github.com/containous/traefik"
 
 GOPATH_IN_CONTAINER=/tmp/go
 PACKAGE_PATH=$GOPATH_IN_CONTAINER/src/$PACKAGE_NAME
-ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 docker build -t "$BUILDER" -f Dockerfile.builder .
 
@@ -16,7 +15,6 @@ docker run --detach=true -t \
     -v $(pwd):$PACKAGE_PATH:Z \
     -u $(id -u $USER):$(id -g $USER) \
     -e GOPATH=$GOPATH_IN_CONTAINER \
-    -e USE_GO_VERSION_FROM_WEBSITE=1 \
     -w $PACKAGE_PATH \
     $BUILDER
 

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -7,6 +7,7 @@ PACKAGE_NAME="github.com/containous/traefik"
 
 GOPATH_IN_CONTAINER=/tmp/go
 PACKAGE_PATH=$GOPATH_IN_CONTAINER/src/$PACKAGE_NAME
+ARG USE_GO_VERSION_FROM_WEBSITE=0
 
 docker build -t "$BUILDER" -f Dockerfile.builder .
 


### PR DESCRIPTION
use `epel-testing` repository to install golang package which was deprecated in CentOS-7
see: https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7.1810#head-e467ac744557df926ed56dc0106f43961e5ffc38