### PR TITLE
move access_token from query param to request header

### DIFF
--- a/integration/osio_middleware_test.go
+++ b/integration/osio_middleware_test.go
@@ -88,6 +88,14 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	log.Printf("Test default server found for OPTIONS request, res.StatusCode=%d", res.StatusCode)
 	c.Assert(res.StatusCode, check.Equals, 200)
 	checkPort(c, res, 8081)
+
+	url := fmt.Sprintf("http://127.0.0.1:8000/test?access_token=%s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "1111"}))
+	req, _ = http.NewRequest("GET", url, nil)
+	res, err = try.Response(req, 500*time.Millisecond)
+	c.Assert(err, check.IsNil)
+	log.Printf("Test server found, res.StatusCode=%d", res.StatusCode)
+	c.Assert(res.StatusCode, check.Equals, 200)
+	checkPort(c, res, 8081)
 }
 
 func checkPort(c *check.C, res *http.Response, expectedPort int) {

--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	Authorization = "Authorization"
+	Authorization          = "Authorization"
 	ImpersonateGroupHeader = "Impersonate-Group"
-	UserIDHeader  = "Impersonate-User"
+	UserIDHeader           = "Impersonate-User"
 )
 
 type RequestType string
@@ -313,10 +313,6 @@ func (r RequestType) getRedirectURL(targetURL string, req *http.Request) string 
 }
 
 func getToken(r *http.Request) (string, error) {
-	if at := r.URL.Query().Get("access_token"); at != "" {
-		r.URL.Query().Del("access_token")
-		return at, nil
-	}
 	t, err := extractToken(r.Header.Get(Authorization))
 	if err != nil {
 		return "", err

--- a/middlewares/osio/osio_request.go
+++ b/middlewares/osio/osio_request.go
@@ -1,0 +1,40 @@
+package osio
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type OSIORequest struct {
+}
+
+func NewOSIORequest() *OSIORequest {
+	return &OSIORequest{}
+}
+
+// ServeHTTP handle OSIORequest middleware. It moves access_token from query param to request header.
+func (a *OSIORequest) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.Method != "OPTIONS" {
+		processAuthParam(r)
+	}
+	next(rw, r)
+}
+
+func processAuthParam(r *http.Request) {
+	accessToken := r.URL.Query().Get("access_token")
+	if accessToken != "" {
+		addAuthHeader(r, accessToken)
+		removeAuthParam(r.URL)
+	}
+}
+
+func addAuthHeader(r *http.Request, accessToken string) {
+	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+}
+
+func removeAuthParam(url *url.URL) {
+	q := url.Query()
+	q.Del("access_token")
+	url.RawQuery = q.Encode()
+}

--- a/middlewares/osio/osio_request.go
+++ b/middlewares/osio/osio_request.go
@@ -3,7 +3,6 @@ package osio
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 )
 
 type OSIORequest struct {
@@ -25,7 +24,7 @@ func processAuthParam(r *http.Request) {
 	accessToken := r.URL.Query().Get("access_token")
 	if accessToken != "" {
 		addAuthHeader(r, accessToken)
-		removeAuthParam(r.URL)
+		removeAuthParam(r)
 	}
 }
 
@@ -33,8 +32,9 @@ func addAuthHeader(r *http.Request, accessToken string) {
 	r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 }
 
-func removeAuthParam(url *url.URL) {
-	q := url.Query()
+func removeAuthParam(r *http.Request) {
+	q := r.URL.Query()
 	q.Del("access_token")
-	url.RawQuery = q.Encode()
+	r.URL.RawQuery = q.Encode()
+	r.RequestURI = r.URL.RequestURI()
 }

--- a/middlewares/osio/osio_request_test.go
+++ b/middlewares/osio/osio_request_test.go
@@ -9,14 +9,27 @@ import (
 )
 
 func TestProcessAuthParam(t *testing.T) {
-	target := "/test?watch=true&access_token=abcd1234"
-	req := httptest.NewRequest(http.MethodGet, target, nil)
+	t.Run("ok", func(t *testing.T) {
+		target := "/test?watch=true&access_token=abcd1234"
+		req := httptest.NewRequest(http.MethodGet, target, nil)
 
-	processAuthParam(req)
+		processAuthParam(req)
 
-	authHeader := req.Header.Get("Authorization")
-	assert.Equal(t, "Bearer abcd1234", authHeader)
-	assert.Empty(t, req.URL.Query().Get("access_token"))
-	assert.Equal(t, "true", req.URL.Query().Get("watch"))
-	assert.Equal(t, "/test?watch=true", req.RequestURI)
+		authHeader := req.Header.Get("Authorization")
+		assert.Equal(t, "Bearer abcd1234", authHeader)
+		assert.Empty(t, req.URL.Query().Get("access_token"))
+		assert.Equal(t, "true", req.URL.Query().Get("watch"))
+		assert.Equal(t, "/test?watch=true", req.RequestURI)
+	})
+
+	t.Run("not_set", func(t *testing.T) {
+		target := "/test?watch=true"
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+
+		processAuthParam(req)
+
+		assert.Empty(t, req.Header.Get("Authorization"))
+		assert.Equal(t, "true", req.URL.Query().Get("watch"))
+		assert.Equal(t, "/test?watch=true", req.RequestURI)
+	})
 }

--- a/middlewares/osio/osio_request_test.go
+++ b/middlewares/osio/osio_request_test.go
@@ -1,0 +1,22 @@
+package osio
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessAuthParam(t *testing.T) {
+	url := "http://osoproxy.com?watch=true&access_token=abcd1234"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	processAuthParam(req)
+
+	authHeader := req.Header.Get("Authorization")
+	assert.Equal(t, "Bearer abcd1234", authHeader)
+	assert.Empty(t, req.URL.Query().Get("access_token"))
+	assert.Equal(t, "true", req.URL.Query().Get("watch"))
+}

--- a/middlewares/osio/osio_request_test.go
+++ b/middlewares/osio/osio_request_test.go
@@ -2,16 +2,15 @@ package osio
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProcessAuthParam(t *testing.T) {
-	url := "http://osoproxy.com?watch=true&access_token=abcd1234"
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	require.NoError(t, err)
+	target := "/test?watch=true&access_token=abcd1234"
+	req := httptest.NewRequest(http.MethodGet, target, nil)
 
 	processAuthParam(req)
 
@@ -19,4 +18,5 @@ func TestProcessAuthParam(t *testing.T) {
 	assert.Equal(t, "Bearer abcd1234", authHeader)
 	assert.Empty(t, req.URL.Query().Get("access_token"))
 	assert.Equal(t, "true", req.URL.Query().Get("watch"))
+	assert.Equal(t, "/test?watch=true", req.RequestURI)
 }


### PR DESCRIPTION
Move access_token from query_param to request_header.  Mainly applicable for web_socket calls.