### PR TITLE
prevent sensitive fields printed in log

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/containous/flaeg"
-	"github.com/containous/traefik-extra-service-fabric"
+	servicefabric "github.com/containous/traefik-extra-service-fabric"
 	"github.com/containous/traefik/acme"
 	"github.com/containous/traefik/api"
 	"github.com/containous/traefik/log"
@@ -402,13 +402,13 @@ func (gc *GlobalConfiguration) initACMEProvider() {
 		if len(saID) <= 0 {
 			panic("Missing SERVICE_ACCOUNT_ID")
 		}
-		gc.OSIO.ServiceAccountID = saID
+		gc.OSIO.ServiceAccountID(saID)
 
 		saSecret := os.Getenv("SERVICE_ACCOUNT_SECRET")
 		if len(saSecret) <= 0 {
 			panic("Missing SERVICE_ACCOUNT_SECRET")
 		}
-		gc.OSIO.ServiceAccountSecret = saSecret
+		gc.OSIO.ServiceAccountSecret(saSecret)
 
 		authURL := os.Getenv("AUTH_URL")
 		if len(authURL) <= 0 {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -398,6 +398,7 @@ func (gc *GlobalConfiguration) initACMEProvider() {
 	}
 
 	if gc.OSIO != nil {
+		log.Info("Initialize OSIO Provider")
 		saID := os.Getenv("SERVICE_ACCOUNT_ID")
 		if len(saID) <= 0 {
 			panic("Missing SERVICE_ACCOUNT_ID")

--- a/provider/osio/osio.go
+++ b/provider/osio/osio.go
@@ -24,15 +24,24 @@ const (
 type Provider struct {
 	provider.BaseProvider `mapstructure:",squash" export:"true"`
 
-	RefreshSeconds       int    `description:"Polling interval (in seconds)" export:"true"`
-	ServiceAccountID     string `description:"Service Account ID" export:"true"`
-	ServiceAccountSecret string `description:"Service Account Secret" export:"true"`
-	TokenURL             string `description:"Auth Token URL" export:"true"`
-	ClustersURL          string `description:"Clusters details URL" export:"true"`
+	RefreshSeconds int    `description:"Polling interval (in seconds)" export:"false"`
+	TokenURL       string `description:"Auth Token URL" export:"true"`
+	ClustersURL    string `description:"Clusters details URL" export:"true"`
+
+	serviceAccountID     string
+	serviceAccountSecret string
 
 	client            Client
 	tokenResp         *TokenResponse
 	defaultBackendURL string
+}
+
+func (p *Provider) ServiceAccountID(saID string) {
+	p.serviceAccountID = saID
+}
+
+func (p *Provider) ServiceAccountSecret(saSecret string) {
+	p.serviceAccountSecret = saSecret
 }
 
 // Provide allows the osio provider to provide configurations to traefik
@@ -120,7 +129,7 @@ func (p *Provider) fetchToken() error {
 	if p.tokenResp != nil {
 		return nil
 	}
-	tokenReq := &TokenRequest{GrantType: "client_credentials", ClientID: p.ServiceAccountID, ClientSecret: p.ServiceAccountSecret}
+	tokenReq := &TokenRequest{GrantType: "client_credentials", ClientID: p.serviceAccountID, ClientSecret: p.serviceAccountSecret}
 	tokenResp, err := p.client.GetToken(p.TokenURL, tokenReq)
 	if err != nil {
 		return err


### PR DESCRIPTION
Un-export `ServiceAccountID` and `serviceAccountSecret` so that it won't included during JSON marshaling.