### PR TITLE
support namespace calls with different users

### DIFF
--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -113,7 +113,7 @@ func NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret string) *OSIOAuth {
 	}
 }
 
-func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, srvAccTokenLocator SrvAccTokenLocator, secretLocator SecretLocator, token string, tokenType TokenType, userID string) Resolver {
+func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, srvAccTokenLocator SrvAccTokenLocator, secretLocator SecretLocator, token string, tokenType TokenType, userID string, namespaceName string) Resolver {
 	return func() (interface{}, error) {
 		namespace, err := tenantLocator.GetTenantById(token, tokenType, userID)
 		if err != nil {
@@ -130,12 +130,12 @@ func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLoca
 			log.Errorf("Failed to locate cluster token, %v", err)
 			return cacheData{}, err
 		}
-		secretName, err := secretLocator.GetName(namespace.ClusterURL, clusterToken, namespace.Name, namespace.Type)
+		secretName, err := secretLocator.GetName(namespace.ClusterURL, clusterToken, namespaceName, namespace.Type)
 		if err != nil {
 			log.Errorf("Failed to locate secret name, %v", err)
 			return cacheData{}, err
 		}
-		osoToken, err := secretLocator.GetSecret(namespace.ClusterURL, clusterToken, namespace.Name, secretName)
+		osoToken, err := secretLocator.GetSecret(namespace.ClusterURL, clusterToken, namespaceName, secretName)
 		if err != nil {
 			log.Errorf("Failed to get secret, %v", err)
 			return cacheData{}, err
@@ -170,10 +170,10 @@ func (a *OSIOAuth) resolveByToken(token string, tokenType TokenType) (cacheData,
 	return cacheData{}, err
 }
 
-func (a *OSIOAuth) resolveByID(userID, token string, tokenType TokenType) (cacheData, error) {
+func (a *OSIOAuth) resolveByID(userID, token string, tokenType TokenType, namespaceName string) (cacheData, error) {
 	plainKey := fmt.Sprintf("%s_%s", token, userID)
 	key := cacheKey(plainKey)
-	val, err := a.cache.Get(key, cacheResolverByID(a.RequestTenantLocation, a.RequestTenantToken, a.RequestSrvAccToken, a.RequestSecretLocation, token, tokenType, userID)).Get()
+	val, err := a.cache.Get(key, cacheResolverByID(a.RequestTenantLocation, a.RequestTenantToken, a.RequestSrvAccToken, a.RequestSecretLocation, token, tokenType, userID, namespaceName)).Get()
 
 	if data, ok := val.(cacheData); ok {
 		return data, err
@@ -209,7 +209,9 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 					rw.WriteHeader(http.StatusUnauthorized)
 					return
 				}
-				cached, err = a.resolveByID(userID, token, tokenType)
+				namespaceName := getNamespaceName(r.URL.Path)
+				log.Infof("namespaceName=%s", namespaceName)
+				cached, err = a.resolveByID(userID, token, tokenType, namespaceName)
 			} else {
 				cached, err = a.resolveByToken(token, tokenType)
 			}
@@ -329,6 +331,26 @@ func extractToken(auth string) (string, error) {
 		return "", fmt.Errorf("Invalid auth")
 	}
 	return auths[len(auths)-1], nil
+}
+
+func getNamespaceName(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	nsPath := "/namespaces/"
+	ind := strings.Index(path, nsPath)
+	if ind == -1 {
+		return ""
+	}
+	startInd := ind + len(nsPath)
+	ind = strings.Index(path[startInd:], "/")
+	if ind == -1 {
+		return path[startInd:]
+	}
+	endInd := startInd + ind
+
+	return path[startInd:endInd]
 }
 
 func cacheKey(plainKey string) string {

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -29,12 +29,12 @@ type testCheData struct {
 /*
 Test case details
 
-call				user								userId			namesapce						cluster					details
-------------------------------------------------------------------------------------------------------------------------------------
-call-1,2		john-preview				11111111		john-preview-che		cluster1.com		std usecase, user & ns for user 11111111 on cluster1
-call-3,4		osio-test-preview		22222222		k8s-image-puller		cluster1.com		daemonset usecase with user 22222222 on cluster1
-call-5			osio-test2-preview	33333333		k8s-image-puller		cluster2.com		daemonset usecase with user 33333333 on cluster2
-call-6			osio-test-preview		22222222		osio-test-preview		cluster1.com		std usecase, user & ns for user 22222222 on cluster1
+call      user                userId    namesapce          cluster       details
+-----------------------------------------------------------------------------------------------------------------------------
+call-1,2  john-preview        11111111  john-preview-che   cluster1.com  std usecase, user & ns for user 11111111 on cluster1
+call-3,4  osio-test-preview   22222222  k8s-image-puller   cluster1.com  daemonset usecase with user 22222222 on cluster1
+call-5    osio-test2-preview  33333333  k8s-image-puller   cluster2.com  daemonset usecase with user 33333333 on cluster2
+call-6    osio-test-preview   22222222  osio-test-preview  cluster1.com  std usecase, user & ns for user 22222222 on cluster1
 
 - between call3 and call5, daemonset usecase with same namespace but different user on different cluster
 - between call3 and call6, same user but call3 is damenset usecase while call6 is std usecase

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -43,13 +43,27 @@ var cheCtx = testCheCtx{tables: []testCheData{
 		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
 		"22222222-1874-4de5-9c62-602634cb5cc2",
 		"127.0.0.1:9091",
-		"1000_che_secret",
+		"2000_che_secret",
 	},
 	{
 		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
 		"22222222-1874-4de5-9c62-602634cb5cc2",
 		"127.0.0.1:9091",
-		"1000_che_secret",
+		"2000_che_secret",
+	},
+	{
+		// same ns=k8s-image-puller but different user=33333333-*
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+		"33333333-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9092",
+		"3000_che_secret",
+	},
+	{
+		// user=22222222-* wants to access its own ns=osio-test-preview-che resuorces
+		"/apis/apps/v1/namespaces/osio-test-preview-che/pods",
+		"22222222-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9091",
+		"4000_che_secret",
 	},
 }}
 
@@ -90,7 +104,7 @@ func TestChe(t *testing.T) {
 
 		cluster.Close()
 	}
-	expecteTenantCalls := 2
+	expecteTenantCalls := 4
 	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 
@@ -275,6 +289,83 @@ func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request
 				"type": "userservices"
 			}
 		}`
+	} else if strings.HasSuffix(req.URL.Path, "/tenants/33333333-1874-4de5-9c62-602634cb5cc2") {
+		res = `{
+			"data": {
+				"attributes": {
+					"created-at": "2018-03-21T11:28:22.042269Z",
+					"namespaces": [
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9092/",
+							"created-at": "2018-03-21T11:28:22.299195Z",
+							"name": "osio-test2-preview-stage",
+							"state": "created",
+							"type": "stage",
+							"updated-at": "2018-03-21T11:28:22.299195Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9092/",
+							"created-at": "2018-03-21T11:28:22.372172Z",
+							"name": "osio-test2-preview-run",
+							"state": "created",
+							"type": "run",
+							"updated-at": "2018-03-21T11:28:22.372172Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9092/",
+							"created-at": "2018-03-21T11:28:22.401522Z",
+							"name": "osio-test2-preview-jenkins",
+							"state": "created",
+							"type": "jenkins",
+							"updated-at": "2018-03-21T11:28:22.401522Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9092/",
+							"created-at": "2018-03-21T11:28:22.413148Z",
+							"name": "osio-test2-preview-che",
+							"state": "created",
+							"type": "che",
+							"updated-at": "2018-03-21T11:28:22.413148Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9092/",
+							"created-at": "2018-03-21T11:28:22.421707Z",
+							"name": "osio-test2-preview",
+							"state": "created",
+							"type": "user",
+							"updated-at": "2018-03-21T11:28:22.421707Z",
+							"version": "1.0.91"
+						}
+					]
+				},
+				"id": "33333333-1874-4de5-9c62-602634cb5cc2",
+				"type": "userservices"
+			}
+		}`
 	} else {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -284,8 +375,12 @@ func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request
 
 func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Request) {
 	res := ""
-	if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/serviceaccounts/che") {
-		res = `{
+	host := req.Host
+
+	if strings.Contains(host, "127.0.0.1:9091") {
+
+		if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/serviceaccounts/che") {
+			res = `{
 			"kind": "ServiceAccount",
 			"apiVersion": "v1",
 			"metadata": {
@@ -317,8 +412,8 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			]
 		  }
 		  `
-	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/serviceaccounts/che") {
-		res = `{
+		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/serviceaccounts/che") {
+			res = `{
 			"kind": "ServiceAccount",
 			"apiVersion": "v1",
 			"metadata": {
@@ -350,8 +445,41 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			]
 		  }
 		  `
-	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/secrets/che-token-x6x6x") {
-		res = `{
+		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/osio-test-preview-che/serviceaccounts/che") {
+			res = `{
+			"kind": "ServiceAccount",
+			"apiVersion": "v1",
+			"metadata": {
+			  "name": "che",
+			  "namespace": "osio-test-preview-che",
+			  "selfLink": "/api/v1/namespaces/osio-test-preview-che/serviceaccounts/che",
+			  "uid": "f9dfcc84-2cfa-11e8-a71f-024db754f2d2",
+			  "resourceVersion": "117908057",
+			  "creationTimestamp": "2018-03-21T11:28:28Z",
+			  "labels": {
+				"app": "fabric8-tenant-che-mt",
+				"group": "io.fabric8.tenant.packages",
+				"provider": "fabric8",
+				"version": "2.0.82"
+			  }
+			},
+			"secrets": [
+			  {
+				"name": "che-dockercfg-x8xx7"
+			  },
+			  {
+				"name": "che-token-x4x4x"
+			  }
+			],
+			"imagePullSecrets": [
+			  {
+				"name": "che-dockercfg-x8xx7"
+			  }
+			]
+		  }
+		  `
+		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/secrets/che-token-x6x6x") {
+			res = `{
 			"kind": "Secret",
 			"apiVersion": "v1",
 			"metadata": {
@@ -374,8 +502,8 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			},
 			"type": "kubernetes.io/service-account-token"
 		  }`
-	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/secrets/che-token-x2x2x") {
-		res = `{
+		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/secrets/che-token-x2x2x") {
+			res = `{
 			"kind": "Secret",
 			"apiVersion": "v1",
 			"metadata": {
@@ -394,11 +522,99 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			  "ca.crt": "xxxxx=",
 			  "namespace": "xxxxx==",
 			  "service-ca.crt": "xxxxx=",
-			  "token": "MTAwMF9jaGVfc2VjcmV0"
+			  "token": "MjAwMF9jaGVfc2VjcmV0"
 			},
 			"type": "kubernetes.io/service-account-token"
 		  }`
-	} else {
+		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/osio-test-preview-che/secrets/che-token-x4x4x") {
+			res = `{
+			"kind": "Secret",
+			"apiVersion": "v1",
+			"metadata": {
+			  "name": "che-token-x4x4x",
+			  "namespace": "osio-test-preview-che",
+			  "selfLink": "/api/v1/namespaces/osio-test-preview-che/secrets/che-token-x4x4x",
+			  "uid": "f9e3f05e-a71f-024db754f2d2",
+			  "resourceVersion": "117908051",
+			  "creationTimestamp": "2018-03-21T11:28:28Z",
+			  "annotations": {
+				"kubernetes.io/service-account.name": "che",
+				"kubernetes.io/service-account.uid": "f9dfcc84-xxx-024db754f2d2"
+			  }
+			},
+			"data": {
+			  "ca.crt": "xxxxx=",
+			  "namespace": "xxxxx==",
+			  "service-ca.crt": "xxxxx=",
+			  "token": "NDAwMF9jaGVfc2VjcmV0"
+			},
+			"type": "kubernetes.io/service-account-token"
+		  }`
+		}
+
+	} else if strings.Contains(host, "127.0.0.1:9092") {
+
+		if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/serviceaccounts/che") {
+			res = `{
+			"kind": "ServiceAccount",
+			"apiVersion": "v1",
+			"metadata": {
+			  "name": "che",
+			  "namespace": "k8s-image-puller",
+			  "selfLink": "/api/v1/namespaces/k8s-image-puller/serviceaccounts/che",
+			  "uid": "f9dfcc84-2cfa-11e8-a71f-024db754f2d2",
+			  "resourceVersion": "117908057",
+			  "creationTimestamp": "2018-03-21T11:28:28Z",
+			  "labels": {
+				"app": "fabric8-tenant-che-mt",
+				"group": "io.fabric8.tenant.packages",
+				"provider": "fabric8",
+				"version": "2.0.82"
+			  }
+			},
+			"secrets": [
+			  {
+				"name": "che-dockercfg-x8xx7"
+			  },
+			  {
+				"name": "che-token-x3x3x"
+			  }
+			],
+			"imagePullSecrets": [
+			  {
+				"name": "che-dockercfg-x8xx7"
+			  }
+			]
+		  }
+		  `
+		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/secrets/che-token-x3x3x") {
+			res = `{
+			"kind": "Secret",
+			"apiVersion": "v1",
+			"metadata": {
+			  "name": "che-token-x3x3x",
+			  "namespace": "k8s-image-puller",
+			  "selfLink": "/api/v1/namespaces/k8s-image-puller/secrets/che-token-x3x3x",
+			  "uid": "f9e3f05e-a71f-024db754f2d2",
+			  "resourceVersion": "117908051",
+			  "creationTimestamp": "2018-03-21T11:28:28Z",
+			  "annotations": {
+				"kubernetes.io/service-account.name": "che",
+				"kubernetes.io/service-account.uid": "f9dfcc84-xxx-024db754f2d2"
+			  }
+			},
+			"data": {
+			  "ca.crt": "xxxxx=",
+			  "namespace": "xxxxx==",
+			  "service-ca.crt": "xxxxx=",
+			  "token": "MzAwMF9jaGVfc2VjcmV0"
+			},
+			"type": "kubernetes.io/service-account-token"
+		  }`
+		}
+	}
+
+	if len(res) == 0 {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -26,6 +26,19 @@ type testCheData struct {
 	expectedToken  string
 }
 
+/*
+Test case details
+
+call				user								userId			namesapce						cluster					details
+------------------------------------------------------------------------------------------------------------------------------------
+call-1,2		john-preview				11111111		john-preview-che		cluster1.com		std usecase, user & ns for user 11111111 on cluster1
+call-3,4		osio-test-preview		22222222		k8s-image-puller		cluster1.com		daemonset usecase with user 22222222 on cluster1
+call-5			osio-test2-preview	33333333		k8s-image-puller		cluster2.com		daemonset usecase with user 33333333 on cluster2
+call-6			osio-test-preview		22222222		osio-test-preview		cluster1.com		std usecase, user & ns for user 22222222 on cluster1
+
+- between call3 and call5, daemonset usecase with same namespace but different user on different cluster
+- between call3 and call6, same user but call3 is damenset usecase while call6 is std usecase
+*/
 var cheCtx = testCheCtx{tables: []testCheData{
 	{
 		"/api/v1/namespaces/john-preview-che/pods",

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -28,14 +28,26 @@ type testCheData struct {
 
 var cheCtx = testCheCtx{tables: []testCheData{
 	{
-		"/api",
-		"john",
+		"/api/v1/namespaces/john-preview-che/pods",
+		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
 		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
 	{
-		"/api",
-		"john",
+		"/api/v1/namespaces/john-preview-che/pods", // same test data to check cache
+		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
+		"127.0.0.1:9091",
+		"1000_che_secret",
+	},
+	{
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+		"22222222-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9091",
+		"1000_che_secret",
+	},
+	{
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
+		"22222222-1874-4de5-9c62-602634cb5cc2",
 		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
@@ -78,7 +90,7 @@ func TestChe(t *testing.T) {
 
 		cluster.Close()
 	}
-	expecteTenantCalls := 1
+	expecteTenantCalls := 2
 	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 
@@ -109,7 +121,7 @@ func (t testCheCtx) serveAuthRequest(rw http.ResponseWriter, req *http.Request) 
 func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request) {
 	cheCtx.tenantCallCount++
 	var res string
-	if strings.HasSuffix(req.URL.Path, "/tenants/john") {
+	if strings.HasSuffix(req.URL.Path, "/tenants/11111111-4c6d-498c-97d0-cc7f2abcaca6") {
 		res = `{
 			"data": {
 			  "attributes": {
@@ -182,10 +194,87 @@ func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request
 				  }
 				]
 			  },
-			  "id": "a25d20d6-4c6d-498c-97d0-cc7f2abcaca6",
+			  "id": "11111111-4c6d-498c-97d0-cc7f2abcaca6",
 			  "type": "userservices"
 			}
 		  }`
+	} else if strings.HasSuffix(req.URL.Path, "/tenants/22222222-1874-4de5-9c62-602634cb5cc2") {
+		res = `{
+			"data": {
+				"attributes": {
+					"created-at": "2018-03-21T11:28:22.042269Z",
+					"namespaces": [
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9091/",
+							"created-at": "2018-03-21T11:28:22.299195Z",
+							"name": "osio-test-preview-stage",
+							"state": "created",
+							"type": "stage",
+							"updated-at": "2018-03-21T11:28:22.299195Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9091/",
+							"created-at": "2018-03-21T11:28:22.372172Z",
+							"name": "osio-test-preview-run",
+							"state": "created",
+							"type": "run",
+							"updated-at": "2018-03-21T11:28:22.372172Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9091/",
+							"created-at": "2018-03-21T11:28:22.401522Z",
+							"name": "osio-test-preview-jenkins",
+							"state": "created",
+							"type": "jenkins",
+							"updated-at": "2018-03-21T11:28:22.401522Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9091/",
+							"created-at": "2018-03-21T11:28:22.413148Z",
+							"name": "osio-test-preview-che",
+							"state": "created",
+							"type": "che",
+							"updated-at": "2018-03-21T11:28:22.413148Z",
+							"version": "2.0.11"
+						},
+						{
+							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
+							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
+							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
+							"cluster-url": "http://127.0.0.1:9091/",
+							"created-at": "2018-03-21T11:28:22.421707Z",
+							"name": "osio-test-preview",
+							"state": "created",
+							"type": "user",
+							"updated-at": "2018-03-21T11:28:22.421707Z",
+							"version": "1.0.91"
+						}
+					]
+				},
+				"id": "22222222-1874-4de5-9c62-602634cb5cc2",
+				"type": "userservices"
+			}
+		}`
 	} else {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -228,6 +317,39 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			]
 		  }
 		  `
+	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/serviceaccounts/che") {
+		res = `{
+			"kind": "ServiceAccount",
+			"apiVersion": "v1",
+			"metadata": {
+			  "name": "che",
+			  "namespace": "k8s-image-puller",
+			  "selfLink": "/api/v1/namespaces/k8s-image-puller/serviceaccounts/che",
+			  "uid": "f9dfcc84-2cfa-11e8-a71f-024db754f2d2",
+			  "resourceVersion": "117908057",
+			  "creationTimestamp": "2018-03-21T11:28:28Z",
+			  "labels": {
+				"app": "fabric8-tenant-che-mt",
+				"group": "io.fabric8.tenant.packages",
+				"provider": "fabric8",
+				"version": "2.0.82"
+			  }
+			},
+			"secrets": [
+			  {
+				"name": "che-dockercfg-x8xx7"
+			  },
+			  {
+				"name": "che-token-x2x2x"
+			  }
+			],
+			"imagePullSecrets": [
+			  {
+				"name": "che-dockercfg-x8xx7"
+			  }
+			]
+		  }
+		  `
 	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/secrets/che-token-x6x6x") {
 		res = `{
 			"kind": "Secret",
@@ -236,6 +358,30 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			  "name": "che-token-x6x6x",
 			  "namespace": "john-preview-che",
 			  "selfLink": "/api/v1/namespaces/john-preview-che/secrets/che-token-x6x6x",
+			  "uid": "f9e3f05e-a71f-024db754f2d2",
+			  "resourceVersion": "117908051",
+			  "creationTimestamp": "2018-03-21T11:28:28Z",
+			  "annotations": {
+				"kubernetes.io/service-account.name": "che",
+				"kubernetes.io/service-account.uid": "f9dfcc84-xxx-024db754f2d2"
+			  }
+			},
+			"data": {
+			  "ca.crt": "xxxxx=",
+			  "namespace": "xxxxx==",
+			  "service-ca.crt": "xxxxx=",
+			  "token": "MTAwMF9jaGVfc2VjcmV0"
+			},
+			"type": "kubernetes.io/service-account-token"
+		  }`
+	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/secrets/che-token-x2x2x") {
+		res = `{
+			"kind": "Secret",
+			"apiVersion": "v1",
+			"metadata": {
+			  "name": "che-token-x2x2x",
+			  "namespace": "k8s-image-puller",
+			  "selfLink": "/api/v1/namespaces/k8s-image-puller/secrets/che-token-x2x2x",
 			  "uid": "f9e3f05e-a71f-024db754f2d2",
 			  "resourceVersion": "117908051",
 			  "creationTimestamp": "2018-03-21T11:28:28Z",

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -57,7 +57,7 @@ func TestRemoveUserID(t *testing.T) {
 		req.Header.Set(ImpersonateGroupHeader, impersonateGroup)
 		removeUserID(req)
 		actualUserID := req.Header.Get(UserIDHeader)
-		actualImpersonateGroup := req.Header.Get(ImpersonateGroupHeader);
+		actualImpersonateGroup := req.Header.Get(ImpersonateGroupHeader)
 		assert.Empty(t, actualUserID)
 		assert.Empty(t, actualImpersonateGroup)
 		assert.Equal(t, "http://f8osoproxy.com", req.URL.String())
@@ -85,6 +85,24 @@ func TestStripPathPrefix(t *testing.T) {
 		reqType := getRequestType(req)
 		reqType.stripPathPrefix(req)
 		assertRequestPath(t, req, table.expectedPath)
+	}
+}
+
+func TestGetNamespaceName(t *testing.T) {
+	tables := []struct {
+		reqPath    string
+		wantNsName string
+	}{
+		{"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", "k8s-image-puller"},
+		{"/apis/apps/v1/namespaces/k8s-image-puller/anything/namespaces/second-namespace/daemonsets", "k8s-image-puller"},
+		{"", ""},
+		{"/apis/apps/v1/ns/k8s-image-puller/daemonsets", ""},
+		{"/apis/apps/v1/namespaces/", ""},
+		{"/apis/apps/v1/namespaces/k8s-image-puller", "k8s-image-puller"},
+	}
+	for _, table := range tables {
+		gotNsName := getNamespaceName(table.reqPath)
+		assert.Equal(t, table.wantNsName, gotNsName)
 	}
 }
 

--- a/middlewares/osio/secret.go
+++ b/middlewares/osio/secret.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/containous/traefik/log"
 )
 
 type secretNameResponse struct {
@@ -37,6 +39,7 @@ func (s *secretLocator) GetName(clusterURL, clusterToken, nsName, nsType string)
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/john-preview-che/serviceaccounts/che
 	clusterURL = normalizeURL(clusterURL)
 	url := fmt.Sprintf("%s/api/v1/namespaces/%s/serviceaccounts/%s", clusterURL, nsName, nsType)
+	log.Infof("GetName, url=%s", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -60,6 +63,7 @@ func (s *secretLocator) GetSecret(clusterURL, clusterToken, nsName, secretName s
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/john-preview-che/secrets/che-token-xxxx
 	clusterURL = normalizeURL(clusterURL)
 	url := fmt.Sprintf("%s/api/v1/namespaces/%s/secrets/%s", clusterURL, nsName, secretName)
+	log.Infof("GetSecret, url=%s", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/ODC-309

che team has requirements where they want to make call with one namespace but want to use different users (other than namespace owner) as `Impersonate-User`.  This PR supports it.

Changes are only made for che specific call.  (i.e. call with che_service_account_token)

Ex call with namespace `k8s-image-puller` but user is `osio-ci-ee3-preview`
```
https://osoproxy.prod-preview.openshift.io/apis/apps/v1/namespaces/k8s-image-puller/daemonsets
Token: CHE_SA_TOKEN
Impersonate-User: 059737ac-0c8d-45bf-9241-e750122a316e (userid of osio-ci-ee3-preview)
```
Note difference against normal calls.  Here namespace is `k8s-image-puller` so ideally user_id of `k8s-image-puller` should be used but here user_id of some other user (i.e. `osio-ci-ee3-preview`) is used.

For above call, `Impersonate-User` only used to find cluster_url.  When making call to get namespace associated service account, `k8s-image-puller` namespace will be used.

On oso_proxy side,
To get cluster_url: https://f8tenant/api/tenants/059737ac-0c8d-45bf-9241-e750122a316e
To get namespace service account: https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/k8s-image-puller/serviceaccounts/che

Here, to get cluster_url, user_id is used.
While to get namespace service account, k8s-image-puller us used.

**cache key for che calls:**
Now, there are two new cases possible with above changes.

_Problem:_
First, there is possibility that same_user (i.e. `osio-ci-ee3-preview`) will be used to access two different namespaces (i.e. `osio-ci-ee3-preview-che` and `k8s-image-puller`)

Second, there is possibility that same_namespace (i.e. `k8s-image-puller`) will be accessed with two different user (i.e. `osio-ci-ee3-preview` on cluster1.com and `osio-ci-ee4-preview` on cluster2.com)

_Solution:_
To make sure, above new cases will be store in cache as new entry, we need to enhance cache_key value.

Before,
cache_key = fmt.Sprintf("%s_%s", token, userID)
After,
cache_key := fmt.Sprintf("%s_%s_%s", token, userID, namespaceName)

Now, namespaceName also part of cache_key.  This will allow to store <cluster_url,token> details for same user with two different namespaces (First case) and same namespace with two different users (Second case).

Note, With this solution, for che calls, there is possibility that multiple entry would be added for same <cluster_url,token> details if che call is made for for same user with different namespace.  For ex, `john-preivew` user call for `john-preview-che` and `john-preview-stage` namespaces then there will be two entry with same <cluster_url,token>.  Normally, che calls made for che namespace only so there is almost no possibility to have this issue.