### PR TITLE
multiple refactoring

### DIFF
--- a/integration/common/osio.go
+++ b/integration/common/osio.go
@@ -9,7 +9,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
+	"github.com/containous/traefik/log"
 	jwt "github.com/dgrijalva/jwt-go"
 	jose "gopkg.in/square/go-jose.v1"
 )
@@ -39,6 +41,31 @@ func StartServer(port int, handler func(w http.ResponseWriter, r *http.Request))
 		ts.Start()
 	}
 	return
+}
+
+// WaitTillReady calls url every seconds for 10 times.
+func WaitTillReady(url string) error {
+	pingReq, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < 10; i++ {
+		log.Printf("/ping request %d", (i + 1))
+		resp, err := http.DefaultClient.Do(pingReq)
+		if err == nil {
+			if resp != nil {
+				if resp.StatusCode == http.StatusOK {
+					if resp.Body != nil {
+						ioutil.ReadAll(resp.Body)
+						resp.Body.Close()
+					}
+					return nil
+				}
+			}
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("url `%s` is not ready after 10 seconds", url)
 }
 
 func ServeTenantRequest(rw http.ResponseWriter, req *http.Request) {

--- a/integration/fixtures/osio_middleware_config.toml
+++ b/integration/fixtures/osio_middleware_config.toml
@@ -17,6 +17,9 @@ format = "json"
     [accessLog.fields.headers.names]
     "Authorization" = "redact"
 
+[ping]
+entrypoint = "http"
+
 [api]
 entryPoint = "traefik"
 

--- a/integration/osio_middleware_test.go
+++ b/integration/osio_middleware_test.go
@@ -46,6 +46,10 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	defer cmd.Process.Kill()
 	defer checkTraefikLogs(c, cmd.Stdout)
 
+	// Wait for Traefik to start
+	err = common.WaitTillReady("http://localhost:8000/ping")
+	c.Assert(err, check.IsNil)
+
 	// Make some requests
 	req, _ := http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "1111"})))

--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -251,7 +251,8 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 func getRequestType(req *http.Request) RequestType {
 	reqPath := req.URL.Path
 	switch {
-	case strings.HasPrefix(reqPath, api.path()):
+	// extra '/' (slash at end) to make sure other prefix like '/apis' should not match with this case
+	case strings.HasPrefix(reqPath, api.path()+"/"):
 		return api
 	case strings.HasPrefix(reqPath, metrics.path()):
 		return metrics

--- a/middlewares/osio/osio_basic_test.go
+++ b/middlewares/osio/osio_basic_test.go
@@ -77,6 +77,13 @@ var mwCtx = testMiddlewareCtx{tables: []testMiddlewareData{
 		"/oapi/anything",
 	},
 	{
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+		"Bearer 1000",
+		"http://api.cluster1.com",
+		"Bearer 1001",
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+	},
+	{
 		"/metrics",
 		"Bearer 1000",
 		"http://metrics.cluster1.com",

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -78,6 +78,7 @@ func TestStripPathPrefix(t *testing.T) {
 		{"/logs/anything", "/anything"},
 		{"/anything", "/anything"},
 		{"/", "/"},
+		{"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", "/apis/apps/v1/namespaces/k8s-image-puller/daemonsets"},
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
- Convert some func to method of `OSIOAuth` which will avoid passing lot of param to func.
- RequestType `api` assignment for path start with `/api/` (before it was path start with `/api` which also consider `/apis` with RequestType=api rather RequestType=undefine.
- Added /ping call in integration test for Traefik readiness.