### PR TITLE
Revert changes made to support k8s-image-puller namespaces

### DIFF
--- a/integration/common/osio.go
+++ b/integration/common/osio.go
@@ -9,9 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"time"
 
-	"github.com/containous/traefik/log"
 	jwt "github.com/dgrijalva/jwt-go"
 	jose "gopkg.in/square/go-jose.v1"
 )
@@ -41,31 +39,6 @@ func StartServer(port int, handler func(w http.ResponseWriter, r *http.Request))
 		ts.Start()
 	}
 	return
-}
-
-// WaitTillReady calls url every seconds for 10 times.
-func WaitTillReady(url string) error {
-	pingReq, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return err
-	}
-	for i := 0; i < 10; i++ {
-		log.Printf("/ping request %d", (i + 1))
-		resp, err := http.DefaultClient.Do(pingReq)
-		if err == nil {
-			if resp != nil {
-				if resp.StatusCode == http.StatusOK {
-					if resp.Body != nil {
-						ioutil.ReadAll(resp.Body)
-						resp.Body.Close()
-					}
-					return nil
-				}
-			}
-		}
-		time.Sleep(1 * time.Second)
-	}
-	return fmt.Errorf("url `%s` is not ready after 10 seconds", url)
 }
 
 func ServeTenantRequest(rw http.ResponseWriter, req *http.Request) {

--- a/integration/fixtures/osio_middleware_config.toml
+++ b/integration/fixtures/osio_middleware_config.toml
@@ -17,9 +17,6 @@ format = "json"
     [accessLog.fields.headers.names]
     "Authorization" = "redact"
 
-[ping]
-entrypoint = "http"
-
 [api]
 entryPoint = "traefik"
 

--- a/integration/osio_middleware_test.go
+++ b/integration/osio_middleware_test.go
@@ -46,10 +46,6 @@ func (s *OSIOMiddlewareSuite) TestOSIO(c *check.C) {
 	defer cmd.Process.Kill()
 	defer checkTraefikLogs(c, cmd.Stdout)
 
-	// Wait for Traefik to start
-	err = common.WaitTillReady("http://localhost:8000/ping")
-	c.Assert(err, check.IsNil)
-
 	// Make some requests
 	req, _ := http.NewRequest("GET", "http://127.0.0.1:8000/test", nil)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", common.TestTokenManager.ToTokenString(jwt.MapClaims{"sub": "1111"})))

--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -113,29 +113,29 @@ func NewOSIOAuth(tenantURL, authURL, srvAccID, srvAccSecret string) *OSIOAuth {
 	}
 }
 
-func (a *OSIOAuth) cacheResolverByID(token string, tokenType TokenType, userID string, namespaceName string) Resolver {
+func cacheResolverByID(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, srvAccTokenLocator SrvAccTokenLocator, secretLocator SecretLocator, token string, tokenType TokenType, userID string, namespaceName string) Resolver {
 	return func() (interface{}, error) {
-		namespace, err := a.RequestTenantLocation.GetTenantById(token, tokenType, userID)
+		namespace, err := tenantLocator.GetTenantById(token, tokenType, userID)
 		if err != nil {
 			log.Errorf("Failed to locate tenant, %v", err)
 			return cacheData{}, err
 		}
-		osoProxySAToken, err := a.RequestSrvAccToken()
+		osoProxySAToken, err := srvAccTokenLocator()
 		if err != nil {
 			log.Errorf("Failed to locate service account token, %v", err)
 			return cacheData{}, err
 		}
-		clusterToken, err := a.RequestTenantToken.GetTokenWithSAToken(osoProxySAToken, namespace.ClusterURL)
+		clusterToken, err := tokenLocator.GetTokenWithSAToken(osoProxySAToken, namespace.ClusterURL)
 		if err != nil {
 			log.Errorf("Failed to locate cluster token, %v", err)
 			return cacheData{}, err
 		}
-		secretName, err := a.RequestSecretLocation.GetName(namespace.ClusterURL, clusterToken, namespaceName, namespace.Type)
+		secretName, err := secretLocator.GetName(namespace.ClusterURL, clusterToken, namespaceName, namespace.Type)
 		if err != nil {
 			log.Errorf("Failed to locate secret name, %v", err)
 			return cacheData{}, err
 		}
-		osoToken, err := a.RequestSecretLocation.GetSecret(namespace.ClusterURL, clusterToken, namespaceName, secretName)
+		osoToken, err := secretLocator.GetSecret(namespace.ClusterURL, clusterToken, namespaceName, secretName)
 		if err != nil {
 			log.Errorf("Failed to get secret, %v", err)
 			return cacheData{}, err
@@ -144,14 +144,14 @@ func (a *OSIOAuth) cacheResolverByID(token string, tokenType TokenType, userID s
 	}
 }
 
-func (a *OSIOAuth) cacheResolverByToken(token string, tokenType TokenType) Resolver {
+func cacheResolverByToken(tenantLocator TenantLocator, tokenLocator TenantTokenLocator, token string, tokenType TokenType) Resolver {
 	return func() (interface{}, error) {
-		namespace, err := a.RequestTenantLocation.GetTenant(token, tokenType)
+		namespace, err := tenantLocator.GetTenant(token, tokenType)
 		if err != nil {
 			log.Errorf("Failed to locate tenant, %v", err)
 			return cacheData{}, err
 		}
-		osoToken, err := a.RequestTenantToken.GetTokenWithUserToken(token, namespace.ClusterURL)
+		osoToken, err := tokenLocator.GetTokenWithUserToken(token, namespace.ClusterURL)
 		if err != nil {
 			log.Errorf("Failed to locate token, %v", err)
 			return cacheData{}, err
@@ -162,7 +162,7 @@ func (a *OSIOAuth) cacheResolverByToken(token string, tokenType TokenType) Resol
 
 func (a *OSIOAuth) resolveByToken(token string, tokenType TokenType) (cacheData, error) {
 	key := cacheKey(token)
-	val, err := a.cache.Get(key, a.cacheResolverByToken(token, tokenType)).Get()
+	val, err := a.cache.Get(key, cacheResolverByToken(a.RequestTenantLocation, a.RequestTenantToken, token, tokenType)).Get()
 
 	if data, ok := val.(cacheData); ok {
 		return data, err
@@ -173,7 +173,7 @@ func (a *OSIOAuth) resolveByToken(token string, tokenType TokenType) (cacheData,
 func (a *OSIOAuth) resolveByID(userID, token string, tokenType TokenType, namespaceName string) (cacheData, error) {
 	plainKey := fmt.Sprintf("%s_%s_%s", token, userID, namespaceName)
 	key := cacheKey(plainKey)
-	val, err := a.cache.Get(key, a.cacheResolverByID(token, tokenType, userID, namespaceName)).Get()
+	val, err := a.cache.Get(key, cacheResolverByID(a.RequestTenantLocation, a.RequestTenantToken, a.RequestSrvAccToken, a.RequestSecretLocation, token, tokenType, userID, namespaceName)).Get()
 
 	if data, ok := val.(cacheData); ok {
 		return data, err
@@ -251,8 +251,7 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 func getRequestType(req *http.Request) RequestType {
 	reqPath := req.URL.Path
 	switch {
-	// extra '/' (slash at end) to make sure other prefix like '/apis' should not match with this case
-	case strings.HasPrefix(reqPath, api.path()+"/"):
+	case strings.HasPrefix(reqPath, api.path()):
 		return api
 	case strings.HasPrefix(reqPath, metrics.path()):
 		return metrics

--- a/middlewares/osio/osio_basic_test.go
+++ b/middlewares/osio/osio_basic_test.go
@@ -77,13 +77,6 @@ var mwCtx = testMiddlewareCtx{tables: []testMiddlewareData{
 		"/oapi/anything",
 	},
 	{
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-		"Bearer 1000",
-		"http://api.cluster1.com",
-		"Bearer 1001",
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-	},
-	{
 		"/metrics",
 		"Bearer 1000",
 		"http://metrics.cluster1.com",

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -26,57 +26,18 @@ type testCheData struct {
 	expectedToken  string
 }
 
-/*
-Test case details
-
-call      user                userId    namesapce          cluster       details
------------------------------------------------------------------------------------------------------------------------------
-call-1,2  john-preview        11111111  john-preview-che   cluster1.com  std usecase, user & ns for user 11111111 on cluster1
-call-3,4  osio-test-preview   22222222  k8s-image-puller   cluster1.com  daemonset usecase with user 22222222 on cluster1
-call-5    osio-test2-preview  33333333  k8s-image-puller   cluster2.com  daemonset usecase with user 33333333 on cluster2
-call-6    osio-test-preview   22222222  osio-test-preview  cluster1.com  std usecase, user & ns for user 22222222 on cluster1
-
-- between call3 and call5, daemonset usecase with same namespace but different user on different cluster
-- between call3 and call6, same user but call3 is damenset usecase while call6 is std usecase
-*/
 var cheCtx = testCheCtx{tables: []testCheData{
 	{
-		"/api/v1/namespaces/john-preview-che/pods",
-		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
+		"/api",
+		"john",
 		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
 	{
-		"/api/v1/namespaces/john-preview-che/pods", // same test data to check cache
-		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
+		"/api",
+		"john",
 		"127.0.0.1:9091",
 		"1000_che_secret",
-	},
-	{
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-		"22222222-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9091",
-		"2000_che_secret",
-	},
-	{
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
-		"22222222-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9091",
-		"2000_che_secret",
-	},
-	{
-		// same ns=k8s-image-puller but different user=33333333-*
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-		"33333333-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9092",
-		"3000_che_secret",
-	},
-	{
-		// user=22222222-* wants to access its own ns=osio-test-preview-che resuorces
-		"/apis/apps/v1/namespaces/osio-test-preview-che/pods",
-		"22222222-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9091",
-		"4000_che_secret",
 	},
 }}
 
@@ -117,7 +78,7 @@ func TestChe(t *testing.T) {
 
 		cluster.Close()
 	}
-	expecteTenantCalls := 4
+	expecteTenantCalls := 1
 	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 
@@ -148,7 +109,7 @@ func (t testCheCtx) serveAuthRequest(rw http.ResponseWriter, req *http.Request) 
 func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request) {
 	cheCtx.tenantCallCount++
 	var res string
-	if strings.HasSuffix(req.URL.Path, "/tenants/11111111-4c6d-498c-97d0-cc7f2abcaca6") {
+	if strings.HasSuffix(req.URL.Path, "/tenants/john") {
 		res = `{
 			"data": {
 			  "attributes": {
@@ -221,164 +182,10 @@ func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request
 				  }
 				]
 			  },
-			  "id": "11111111-4c6d-498c-97d0-cc7f2abcaca6",
+			  "id": "a25d20d6-4c6d-498c-97d0-cc7f2abcaca6",
 			  "type": "userservices"
 			}
 		  }`
-	} else if strings.HasSuffix(req.URL.Path, "/tenants/22222222-1874-4de5-9c62-602634cb5cc2") {
-		res = `{
-			"data": {
-				"attributes": {
-					"created-at": "2018-03-21T11:28:22.042269Z",
-					"namespaces": [
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9091/",
-							"created-at": "2018-03-21T11:28:22.299195Z",
-							"name": "osio-test-preview-stage",
-							"state": "created",
-							"type": "stage",
-							"updated-at": "2018-03-21T11:28:22.299195Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9091/",
-							"created-at": "2018-03-21T11:28:22.372172Z",
-							"name": "osio-test-preview-run",
-							"state": "created",
-							"type": "run",
-							"updated-at": "2018-03-21T11:28:22.372172Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9091/",
-							"created-at": "2018-03-21T11:28:22.401522Z",
-							"name": "osio-test-preview-jenkins",
-							"state": "created",
-							"type": "jenkins",
-							"updated-at": "2018-03-21T11:28:22.401522Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9091/",
-							"created-at": "2018-03-21T11:28:22.413148Z",
-							"name": "osio-test-preview-che",
-							"state": "created",
-							"type": "che",
-							"updated-at": "2018-03-21T11:28:22.413148Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9091/",
-							"created-at": "2018-03-21T11:28:22.421707Z",
-							"name": "osio-test-preview",
-							"state": "created",
-							"type": "user",
-							"updated-at": "2018-03-21T11:28:22.421707Z",
-							"version": "1.0.91"
-						}
-					]
-				},
-				"id": "22222222-1874-4de5-9c62-602634cb5cc2",
-				"type": "userservices"
-			}
-		}`
-	} else if strings.HasSuffix(req.URL.Path, "/tenants/33333333-1874-4de5-9c62-602634cb5cc2") {
-		res = `{
-			"data": {
-				"attributes": {
-					"created-at": "2018-03-21T11:28:22.042269Z",
-					"namespaces": [
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9092/",
-							"created-at": "2018-03-21T11:28:22.299195Z",
-							"name": "osio-test2-preview-stage",
-							"state": "created",
-							"type": "stage",
-							"updated-at": "2018-03-21T11:28:22.299195Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9092/",
-							"created-at": "2018-03-21T11:28:22.372172Z",
-							"name": "osio-test2-preview-run",
-							"state": "created",
-							"type": "run",
-							"updated-at": "2018-03-21T11:28:22.372172Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9092/",
-							"created-at": "2018-03-21T11:28:22.401522Z",
-							"name": "osio-test2-preview-jenkins",
-							"state": "created",
-							"type": "jenkins",
-							"updated-at": "2018-03-21T11:28:22.401522Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9092/",
-							"created-at": "2018-03-21T11:28:22.413148Z",
-							"name": "osio-test2-preview-che",
-							"state": "created",
-							"type": "che",
-							"updated-at": "2018-03-21T11:28:22.413148Z",
-							"version": "2.0.11"
-						},
-						{
-							"cluster-app-domain": "b542.starter-us-east-2a.openshiftapps.com",
-							"cluster-console-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-logging-url": "https://console.starter-us-east-2a.openshift.com/console/",
-							"cluster-metrics-url": "https://metrics.starter-us-east-2a.openshift.com/",
-							"cluster-url": "http://127.0.0.1:9092/",
-							"created-at": "2018-03-21T11:28:22.421707Z",
-							"name": "osio-test2-preview",
-							"state": "created",
-							"type": "user",
-							"updated-at": "2018-03-21T11:28:22.421707Z",
-							"version": "1.0.91"
-						}
-					]
-				},
-				"id": "33333333-1874-4de5-9c62-602634cb5cc2",
-				"type": "userservices"
-			}
-		}`
 	} else {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
@@ -388,12 +195,8 @@ func (t testCheCtx) serveTenantRequest(rw http.ResponseWriter, req *http.Request
 
 func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Request) {
 	res := ""
-	host := req.Host
-
-	if strings.Contains(host, "127.0.0.1:9091") {
-
-		if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/serviceaccounts/che") {
-			res = `{
+	if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/serviceaccounts/che") {
+		res = `{
 			"kind": "ServiceAccount",
 			"apiVersion": "v1",
 			"metadata": {
@@ -425,74 +228,8 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			]
 		  }
 		  `
-		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/serviceaccounts/che") {
-			res = `{
-			"kind": "ServiceAccount",
-			"apiVersion": "v1",
-			"metadata": {
-			  "name": "che",
-			  "namespace": "k8s-image-puller",
-			  "selfLink": "/api/v1/namespaces/k8s-image-puller/serviceaccounts/che",
-			  "uid": "f9dfcc84-2cfa-11e8-a71f-024db754f2d2",
-			  "resourceVersion": "117908057",
-			  "creationTimestamp": "2018-03-21T11:28:28Z",
-			  "labels": {
-				"app": "fabric8-tenant-che-mt",
-				"group": "io.fabric8.tenant.packages",
-				"provider": "fabric8",
-				"version": "2.0.82"
-			  }
-			},
-			"secrets": [
-			  {
-				"name": "che-dockercfg-x8xx7"
-			  },
-			  {
-				"name": "che-token-x2x2x"
-			  }
-			],
-			"imagePullSecrets": [
-			  {
-				"name": "che-dockercfg-x8xx7"
-			  }
-			]
-		  }
-		  `
-		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/osio-test-preview-che/serviceaccounts/che") {
-			res = `{
-			"kind": "ServiceAccount",
-			"apiVersion": "v1",
-			"metadata": {
-			  "name": "che",
-			  "namespace": "osio-test-preview-che",
-			  "selfLink": "/api/v1/namespaces/osio-test-preview-che/serviceaccounts/che",
-			  "uid": "f9dfcc84-2cfa-11e8-a71f-024db754f2d2",
-			  "resourceVersion": "117908057",
-			  "creationTimestamp": "2018-03-21T11:28:28Z",
-			  "labels": {
-				"app": "fabric8-tenant-che-mt",
-				"group": "io.fabric8.tenant.packages",
-				"provider": "fabric8",
-				"version": "2.0.82"
-			  }
-			},
-			"secrets": [
-			  {
-				"name": "che-dockercfg-x8xx7"
-			  },
-			  {
-				"name": "che-token-x4x4x"
-			  }
-			],
-			"imagePullSecrets": [
-			  {
-				"name": "che-dockercfg-x8xx7"
-			  }
-			]
-		  }
-		  `
-		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/secrets/che-token-x6x6x") {
-			res = `{
+	} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/john-preview-che/secrets/che-token-x6x6x") {
+		res = `{
 			"kind": "Secret",
 			"apiVersion": "v1",
 			"metadata": {
@@ -515,119 +252,7 @@ func (t testCheCtx) serveClusterRequest(rw http.ResponseWriter, req *http.Reques
 			},
 			"type": "kubernetes.io/service-account-token"
 		  }`
-		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/secrets/che-token-x2x2x") {
-			res = `{
-			"kind": "Secret",
-			"apiVersion": "v1",
-			"metadata": {
-			  "name": "che-token-x2x2x",
-			  "namespace": "k8s-image-puller",
-			  "selfLink": "/api/v1/namespaces/k8s-image-puller/secrets/che-token-x2x2x",
-			  "uid": "f9e3f05e-a71f-024db754f2d2",
-			  "resourceVersion": "117908051",
-			  "creationTimestamp": "2018-03-21T11:28:28Z",
-			  "annotations": {
-				"kubernetes.io/service-account.name": "che",
-				"kubernetes.io/service-account.uid": "f9dfcc84-xxx-024db754f2d2"
-			  }
-			},
-			"data": {
-			  "ca.crt": "xxxxx=",
-			  "namespace": "xxxxx==",
-			  "service-ca.crt": "xxxxx=",
-			  "token": "MjAwMF9jaGVfc2VjcmV0"
-			},
-			"type": "kubernetes.io/service-account-token"
-		  }`
-		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/osio-test-preview-che/secrets/che-token-x4x4x") {
-			res = `{
-			"kind": "Secret",
-			"apiVersion": "v1",
-			"metadata": {
-			  "name": "che-token-x4x4x",
-			  "namespace": "osio-test-preview-che",
-			  "selfLink": "/api/v1/namespaces/osio-test-preview-che/secrets/che-token-x4x4x",
-			  "uid": "f9e3f05e-a71f-024db754f2d2",
-			  "resourceVersion": "117908051",
-			  "creationTimestamp": "2018-03-21T11:28:28Z",
-			  "annotations": {
-				"kubernetes.io/service-account.name": "che",
-				"kubernetes.io/service-account.uid": "f9dfcc84-xxx-024db754f2d2"
-			  }
-			},
-			"data": {
-			  "ca.crt": "xxxxx=",
-			  "namespace": "xxxxx==",
-			  "service-ca.crt": "xxxxx=",
-			  "token": "NDAwMF9jaGVfc2VjcmV0"
-			},
-			"type": "kubernetes.io/service-account-token"
-		  }`
-		}
-
-	} else if strings.Contains(host, "127.0.0.1:9092") {
-
-		if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/serviceaccounts/che") {
-			res = `{
-			"kind": "ServiceAccount",
-			"apiVersion": "v1",
-			"metadata": {
-			  "name": "che",
-			  "namespace": "k8s-image-puller",
-			  "selfLink": "/api/v1/namespaces/k8s-image-puller/serviceaccounts/che",
-			  "uid": "f9dfcc84-2cfa-11e8-a71f-024db754f2d2",
-			  "resourceVersion": "117908057",
-			  "creationTimestamp": "2018-03-21T11:28:28Z",
-			  "labels": {
-				"app": "fabric8-tenant-che-mt",
-				"group": "io.fabric8.tenant.packages",
-				"provider": "fabric8",
-				"version": "2.0.82"
-			  }
-			},
-			"secrets": [
-			  {
-				"name": "che-dockercfg-x8xx7"
-			  },
-			  {
-				"name": "che-token-x3x3x"
-			  }
-			],
-			"imagePullSecrets": [
-			  {
-				"name": "che-dockercfg-x8xx7"
-			  }
-			]
-		  }
-		  `
-		} else if strings.HasSuffix(req.URL.Path, "api/v1/namespaces/k8s-image-puller/secrets/che-token-x3x3x") {
-			res = `{
-			"kind": "Secret",
-			"apiVersion": "v1",
-			"metadata": {
-			  "name": "che-token-x3x3x",
-			  "namespace": "k8s-image-puller",
-			  "selfLink": "/api/v1/namespaces/k8s-image-puller/secrets/che-token-x3x3x",
-			  "uid": "f9e3f05e-a71f-024db754f2d2",
-			  "resourceVersion": "117908051",
-			  "creationTimestamp": "2018-03-21T11:28:28Z",
-			  "annotations": {
-				"kubernetes.io/service-account.name": "che",
-				"kubernetes.io/service-account.uid": "f9dfcc84-xxx-024db754f2d2"
-			  }
-			},
-			"data": {
-			  "ca.crt": "xxxxx=",
-			  "namespace": "xxxxx==",
-			  "service-ca.crt": "xxxxx=",
-			  "token": "MzAwMF9jaGVfc2VjcmV0"
-			},
-			"type": "kubernetes.io/service-account-token"
-		  }`
-		}
-	}
-
-	if len(res) == 0 {
+	} else {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -78,7 +78,6 @@ func TestStripPathPrefix(t *testing.T) {
 		{"/logs/anything", "/anything"},
 		{"/anything", "/anything"},
 		{"/", "/"},
-		{"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", "/apis/apps/v1/namespaces/k8s-image-puller/daemonsets"},
 	}
 
 	for _, table := range tables {

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -57,7 +57,7 @@ func TestRemoveUserID(t *testing.T) {
 		req.Header.Set(ImpersonateGroupHeader, impersonateGroup)
 		removeUserID(req)
 		actualUserID := req.Header.Get(UserIDHeader)
-		actualImpersonateGroup := req.Header.Get(ImpersonateGroupHeader)
+		actualImpersonateGroup := req.Header.Get(ImpersonateGroupHeader);
 		assert.Empty(t, actualUserID)
 		assert.Empty(t, actualImpersonateGroup)
 		assert.Equal(t, "http://f8osoproxy.com", req.URL.String())
@@ -85,24 +85,6 @@ func TestStripPathPrefix(t *testing.T) {
 		reqType := getRequestType(req)
 		reqType.stripPathPrefix(req)
 		assertRequestPath(t, req, table.expectedPath)
-	}
-}
-
-func TestGetNamespaceName(t *testing.T) {
-	tables := []struct {
-		reqPath    string
-		wantNsName string
-	}{
-		{"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", "k8s-image-puller"},
-		{"/apis/apps/v1/namespaces/k8s-image-puller/anything/namespaces/second-namespace/daemonsets", "k8s-image-puller"},
-		{"", ""},
-		{"/apis/apps/v1/ns/k8s-image-puller/daemonsets", ""},
-		{"/apis/apps/v1/namespaces/", ""},
-		{"/apis/apps/v1/namespaces/k8s-image-puller", "k8s-image-puller"},
-	}
-	for _, table := range tables {
-		gotNsName := getNamespaceName(table.reqPath)
-		assert.Equal(t, table.wantNsName, gotNsName)
 	}
 }
 

--- a/middlewares/osio/secret.go
+++ b/middlewares/osio/secret.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/containous/traefik/log"
 )
 
 type secretNameResponse struct {
@@ -39,7 +37,6 @@ func (s *secretLocator) GetName(clusterURL, clusterToken, nsName, nsType string)
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/john-preview-che/serviceaccounts/che
 	clusterURL = normalizeURL(clusterURL)
 	url := fmt.Sprintf("%s/api/v1/namespaces/%s/serviceaccounts/%s", clusterURL, nsName, nsType)
-	log.Infof("GetName, url=%s", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
@@ -63,7 +60,6 @@ func (s *secretLocator) GetSecret(clusterURL, clusterToken, nsName, secretName s
 	// https://api.starter-us-east-2a.openshift.com/api/v1/namespaces/john-preview-che/secrets/che-token-xxxx
 	clusterURL = normalizeURL(clusterURL)
 	url := fmt.Sprintf("%s/api/v1/namespaces/%s/secrets/%s", clusterURL, nsName, secretName)
-	log.Infof("GetSecret, url=%s", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Reverts 
- https://github.com/fabric8-services/fabric8-oso-proxy/commit/418287a0b0872b207ed7e8a6ed7e788825b11c4a
- https://github.com/fabric8-services/fabric8-oso-proxy/commit/418287a0b0872b207ed7e8a6ed7e788825b11c4a

Just having this reverting PR in case we can't fix the problem quick enough.