### PR TITLE
disable usage of namespace name

### DIFF
--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -130,12 +130,12 @@ func (a *OSIOAuth) cacheResolverByID(token string, tokenType TokenType, userID s
 			log.Errorf("Failed to locate cluster token, %v", err)
 			return cacheData{}, err
 		}
-		secretName, err := a.RequestSecretLocation.GetName(namespace.ClusterURL, clusterToken, namespaceName, namespace.Type)
+		secretName, err := a.RequestSecretLocation.GetName(namespace.ClusterURL, clusterToken, namespace.Name, namespace.Type)
 		if err != nil {
 			log.Errorf("Failed to locate secret name, %v", err)
 			return cacheData{}, err
 		}
-		osoToken, err := a.RequestSecretLocation.GetSecret(namespace.ClusterURL, clusterToken, namespaceName, secretName)
+		osoToken, err := a.RequestSecretLocation.GetSecret(namespace.ClusterURL, clusterToken, namespace.Name, secretName)
 		if err != nil {
 			log.Errorf("Failed to get secret, %v", err)
 			return cacheData{}, err
@@ -171,7 +171,7 @@ func (a *OSIOAuth) resolveByToken(token string, tokenType TokenType) (cacheData,
 }
 
 func (a *OSIOAuth) resolveByID(userID, token string, tokenType TokenType, namespaceName string) (cacheData, error) {
-	plainKey := fmt.Sprintf("%s_%s_%s", token, userID, namespaceName)
+	plainKey := fmt.Sprintf("%s_%s", token, userID)
 	key := cacheKey(plainKey)
 	val, err := a.cache.Get(key, a.cacheResolverByID(token, tokenType, userID, namespaceName)).Get()
 
@@ -203,6 +203,8 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 			// retrieve cache data
 			var cached cacheData
 			if tokenType != UserToken {
+				log.Infof("Got che call, host='%s' and path='%s'", r.Host, r.URL.Path)
+
 				userID := extractUserID(r)
 				if userID == "" {
 					log.Errorf("user identity is missing")
@@ -210,11 +212,11 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 					return
 				}
 				namespaceName := getNamespaceName(r.URL.Path)
-				log.Infof("namespaceName=%s", namespaceName)
+				log.Infof("namespaceName='%s'", namespaceName)
 				if namespaceName == "" {
-					log.Errorf("Invalid path, namespace name is missing in request path")
-					rw.WriteHeader(http.StatusBadRequest)
-					return
+					log.Warnf("Invalid path, namespace name is missing in request path, host='%s', path='%s'", r.Host, r.URL.Path)
+					// rw.WriteHeader(http.StatusBadRequest)
+					// return
 				}
 				cached, err = a.resolveByID(userID, token, tokenType, namespaceName)
 			} else {

--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -214,7 +214,7 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 				namespaceName := getNamespaceName(r.URL.Path)
 				log.Infof("namespaceName='%s'", namespaceName)
 				if namespaceName == "" {
-					log.Warnf("Invalid path, namespace name is missing in request path, host='%s', path='%s'", r.Host, r.URL.Path)
+					log.Warnf("Invalid path, namespace name is missing in request path, host='%s', path='%s', userID='%s'", r.Host, r.URL.Path, userID)
 					// rw.WriteHeader(http.StatusBadRequest)
 					// return
 				}

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -52,32 +52,32 @@ var cheCtx = testCheCtx{tables: []testCheData{
 		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
-	{
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-		"22222222-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9091",
-		"2000_che_secret",
-	},
-	{
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
-		"22222222-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9091",
-		"2000_che_secret",
-	},
-	{
-		// same ns=k8s-image-puller but different user=33333333-*
-		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-		"33333333-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9092",
-		"3000_che_secret",
-	},
-	{
-		// user=22222222-* wants to access its own ns=osio-test-preview-che resuorces
-		"/apis/apps/v1/namespaces/osio-test-preview-che/pods",
-		"22222222-1874-4de5-9c62-602634cb5cc2",
-		"127.0.0.1:9091",
-		"4000_che_secret",
-	},
+	// {
+	// 	"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+	// 	"22222222-1874-4de5-9c62-602634cb5cc2",
+	// 	"127.0.0.1:9091",
+	// 	"2000_che_secret",
+	// },
+	// {
+	// 	"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
+	// 	"22222222-1874-4de5-9c62-602634cb5cc2",
+	// 	"127.0.0.1:9091",
+	// 	"2000_che_secret",
+	// },
+	// {
+	// 	// same ns=k8s-image-puller but different user=33333333-*
+	// 	"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+	// 	"33333333-1874-4de5-9c62-602634cb5cc2",
+	// 	"127.0.0.1:9092",
+	// 	"3000_che_secret",
+	// },
+	// {
+	// 	// user=22222222-* wants to access its own ns=osio-test-preview-che resuorces
+	// 	"/apis/apps/v1/namespaces/osio-test-preview-che/pods",
+	// 	"22222222-1874-4de5-9c62-602634cb5cc2",
+	// 	"127.0.0.1:9091",
+	// 	"4000_che_secret",
+	// },
 }}
 
 func TestChe(t *testing.T) {
@@ -113,11 +113,11 @@ func TestChe(t *testing.T) {
 		assert.NotNil(t, res)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
 		errMsg := res.Header.Get("err")
-		assert.Empty(t, errMsg, errMsg)
+		assert.Empty(t, errMsg, "Test fail for, path=%s, id=%s", currReqPath, table.userID)
 
 		cluster.Close()
 	}
-	expecteTenantCalls := 4
+	expecteTenantCalls := 1
 	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 

--- a/middlewares/osio/osio_test.go
+++ b/middlewares/osio/osio_test.go
@@ -103,7 +103,28 @@ func TestGetNamespaceName(t *testing.T) {
 	}
 	for _, table := range tables {
 		gotNsName := getNamespaceName(table.reqPath)
-		assert.Equal(t, table.wantNsName, gotNsName)
+		assert.Equalf(t, table.wantNsName, gotNsName, "reqPath=%s", table.reqPath)
+	}
+}
+
+func TestGetNamespaceNameCheCalls(t *testing.T) {
+	tables := []struct {
+		reqPath    string
+		wantNsName string
+	}{
+		{"/api/v1/namespaces/nvirani-preview-che/pods/mkdir-workspacetqd6n4vlizkszspx", "nvirani-preview-che"},
+		{"/apis/route.openshift.io/v1/namespaces/nvirani-preview-che/routes", "nvirani-preview-che"},
+		{"/apis/apps/v1/namespaces/nvirani-preview-che/deployments", "nvirani-preview-che"},
+		{"/api/v1/namespaces/nvirani-preview-che/events", "nvirani-preview-che"},
+		{"/api/v1/namespaces/nvirani-preview-che/persistentvolumeclaims", "nvirani-preview-che"},
+		{"/api/v1/namespaces/nvirani-preview-che/pods", "nvirani-preview-che"},
+		{"/api/v1/namespaces/nvirani-preview-che/services", "nvirani-preview-che"},
+		{"/api/v1/namespaces/nvirani-preview-che/pods/workspacetqd6n4vlizkszspx.dockerimage-5c757cbbf8-28b5b", "nvirani-preview-che"},
+		{"/api/v1/namespaces/nvirani-preview-che/pods/workspacetqd6n4vlizkszspx.dockerimage-5c757cbbf8-28b5b/exec", "nvirani-preview-che"},
+	}
+	for _, table := range tables {
+		gotNsName := getNamespaceName(table.reqPath)
+		assert.Equalf(t, table.wantNsName, gotNsName, "reqPath=%s", table.reqPath)
 	}
 }
 


### PR DESCRIPTION
To further analyze issue https://github.com/redhat-developer/che-functional-tests/issues/470 we have added logs and disable usage of namespace name.  Below are the changes.

1. Added tests for namespace name with che specific url.
2. Remove usage of namespace name.  Namespace name is only logged and pass around method param but not used in actual logic.