### PR TITLE
use ns from request url or fall back to ns from tenant service

### DIFF
--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -200,7 +200,6 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 	if a.RequestTenantLocation != nil {
 
 		if r.Method != "OPTIONS" {
-			log.Infof("Got request, host='%s' and path='%s'", r.Host, r.URL.Path)
 			// get token and token type
 			token, err := getToken(r)
 			if err != nil {
@@ -214,13 +213,10 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 				rw.WriteHeader(http.StatusUnauthorized)
 				return
 			}
-			log.Infof("tokenType='%s'", tokenType)
 
 			// retrieve cache data
 			var cached cacheData
 			if tokenType != UserToken {
-				log.Infof("Got che call, host='%s' and path='%s'", r.Host, r.URL.Path)
-
 				userID := extractUserID(r)
 				if userID == "" {
 					log.Errorf("user identity is missing")
@@ -228,7 +224,6 @@ func (a *OSIOAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.
 					return
 				}
 				namespaceName := getNamespaceName(r.URL.Path)
-				log.Infof("namespaceName='%s'", namespaceName)
 				if namespaceName == "" {
 					log.Infof("Cache disabled for this call as 'namespace name' is missing in request path, host='%s', path='%s', userID='%s'", r.Host, r.URL.Path, userID)
 					cached, err = a.resolveByIDWithoutCache(userID, token, tokenType, namespaceName)

--- a/middlewares/osio/osio.go
+++ b/middlewares/osio/osio.go
@@ -120,6 +120,10 @@ func (a *OSIOAuth) cacheResolverByID(token string, tokenType TokenType, userID s
 			log.Errorf("Failed to locate tenant, %v", err)
 			return cacheData{}, err
 		}
+		if namespaceName == "" {
+			namespaceName = namespace.Name
+		}
+
 		osoProxySAToken, err := a.RequestSrvAccToken()
 		if err != nil {
 			log.Errorf("Failed to locate service account token, %v", err)
@@ -130,12 +134,12 @@ func (a *OSIOAuth) cacheResolverByID(token string, tokenType TokenType, userID s
 			log.Errorf("Failed to locate cluster token, %v", err)
 			return cacheData{}, err
 		}
-		secretName, err := a.RequestSecretLocation.GetName(namespace.ClusterURL, clusterToken, namespace.Name, namespace.Type)
+		secretName, err := a.RequestSecretLocation.GetName(namespace.ClusterURL, clusterToken, namespaceName, namespace.Type)
 		if err != nil {
 			log.Errorf("Failed to locate secret name, %v", err)
 			return cacheData{}, err
 		}
-		osoToken, err := a.RequestSecretLocation.GetSecret(namespace.ClusterURL, clusterToken, namespace.Name, secretName)
+		osoToken, err := a.RequestSecretLocation.GetSecret(namespace.ClusterURL, clusterToken, namespaceName, secretName)
 		if err != nil {
 			log.Errorf("Failed to get secret, %v", err)
 			return cacheData{}, err
@@ -171,7 +175,7 @@ func (a *OSIOAuth) resolveByToken(token string, tokenType TokenType) (cacheData,
 }
 
 func (a *OSIOAuth) resolveByID(userID, token string, tokenType TokenType, namespaceName string) (cacheData, error) {
-	plainKey := fmt.Sprintf("%s_%s", token, userID)
+	plainKey := fmt.Sprintf("%s_%s_%s", token, userID, namespaceName)
 	key := cacheKey(plainKey)
 	val, err := a.cache.Get(key, a.cacheResolverByID(token, tokenType, userID, namespaceName)).Get()
 

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -53,12 +53,6 @@ var cheCtx = testCheCtx{tables: []testCheData{
 		"1000_che_secret",
 	},
 	{
-		"/",
-		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
-		"127.0.0.1:9091",
-		"1000_che_secret",
-	},
-	{
 		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
 		"22222222-1874-4de5-9c62-602634cb5cc2",
 		"127.0.0.1:9091",
@@ -83,6 +77,19 @@ var cheCtx = testCheCtx{tables: []testCheData{
 		"22222222-1874-4de5-9c62-602634cb5cc2",
 		"127.0.0.1:9091",
 		"4000_che_secret",
+	},
+	// two calls without namespace and cache disabled for both calls
+	{
+		"/",
+		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
+		"127.0.0.1:9091",
+		"1000_che_secret",
+	},
+	{
+		"/",
+		"11111111-4c6d-498c-97d0-cc7f2abcaca6",
+		"127.0.0.1:9091",
+		"1000_che_secret",
 	},
 }}
 
@@ -123,7 +130,7 @@ func TestChe(t *testing.T) {
 
 		cluster.Close()
 	}
-	expecteTenantCalls := 5
+	expecteTenantCalls := 6
 	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 

--- a/middlewares/osio/osio_che_test.go
+++ b/middlewares/osio/osio_che_test.go
@@ -58,32 +58,32 @@ var cheCtx = testCheCtx{tables: []testCheData{
 		"127.0.0.1:9091",
 		"1000_che_secret",
 	},
-	// {
-	// 	"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-	// 	"22222222-1874-4de5-9c62-602634cb5cc2",
-	// 	"127.0.0.1:9091",
-	// 	"2000_che_secret",
-	// },
-	// {
-	// 	"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
-	// 	"22222222-1874-4de5-9c62-602634cb5cc2",
-	// 	"127.0.0.1:9091",
-	// 	"2000_che_secret",
-	// },
-	// {
-	// 	// same ns=k8s-image-puller but different user=33333333-*
-	// 	"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
-	// 	"33333333-1874-4de5-9c62-602634cb5cc2",
-	// 	"127.0.0.1:9092",
-	// 	"3000_che_secret",
-	// },
-	// {
-	// 	// user=22222222-* wants to access its own ns=osio-test-preview-che resuorces
-	// 	"/apis/apps/v1/namespaces/osio-test-preview-che/pods",
-	// 	"22222222-1874-4de5-9c62-602634cb5cc2",
-	// 	"127.0.0.1:9091",
-	// 	"4000_che_secret",
-	// },
+	{
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+		"22222222-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9091",
+		"2000_che_secret",
+	},
+	{
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets", // same test data to check cache
+		"22222222-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9091",
+		"2000_che_secret",
+	},
+	{
+		// same ns=k8s-image-puller but different user=33333333-*
+		"/apis/apps/v1/namespaces/k8s-image-puller/daemonsets",
+		"33333333-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9092",
+		"3000_che_secret",
+	},
+	{
+		// user=22222222-* wants to access its own ns=osio-test-preview-che resuorces
+		"/apis/apps/v1/namespaces/osio-test-preview-che/pods",
+		"22222222-1874-4de5-9c62-602634cb5cc2",
+		"127.0.0.1:9091",
+		"4000_che_secret",
+	},
 }}
 
 func TestChe(t *testing.T) {
@@ -117,13 +117,13 @@ func TestChe(t *testing.T) {
 		req.Header.Set(UserIDHeader, table.userID)
 		res, _ := http.DefaultClient.Do(req)
 		assert.NotNil(t, res)
-		assert.Equal(t, http.StatusOK, res.StatusCode)
+		assert.Equal(t, http.StatusOK, res.StatusCode, "Test fail for, path=%s, id=%s", currReqPath, table.userID)
 		errMsg := res.Header.Get("err")
 		assert.Empty(t, errMsg, "Test fail for, path=%s, id=%s", currReqPath, table.userID)
 
 		cluster.Close()
 	}
-	expecteTenantCalls := 2
+	expecteTenantCalls := 5
 	assert.Equal(t, expecteTenantCalls, cheCtx.tenantCallCount, "Number of time Tenant server called was incorrect, want:%d, got:%d", expecteTenantCalls, cheCtx.tenantCallCount)
 }
 


### PR DESCRIPTION
This PR is about bring back changes from previous PR merged for damensets requirments.
PR - https://github.com/fabric8-services/fabric8-oso-proxy/pull/50