### PR TITLE
enhance cache resolution for error scenario

### DIFF
--- a/middlewares/osio/cache.go
+++ b/middlewares/osio/cache.go
@@ -50,7 +50,10 @@ func (r *ResolverPromise) Get() (interface{}, error) {
 
 	}(&wg, r.resolver)
 	wg.Wait()
-	r.resolved = true
+
+	if r.err == nil {
+		r.resolved = true
+	}
 
 	return r.value, r.err
 }


### PR DESCRIPTION
**Problem:**
Currently, cache keeps the resolver result [val,err] even though error is NOT nil. [code_link](https://github.com/fabric8-services/fabric8-oso-proxy/blob/master/middlewares/osio/cache.go#L53)

This is problematic behavior.  It's possible that resolver return error due to temporary issue (for ex, network issue).  Later, if you retry with resolver, it may work and return result with value and nil error.

This is particularly problematic when cluster_token is changed.  We are using cluster_token here [code_link](https://github.com/fabric8-services/fabric8-oso-proxy/blob/master/middlewares/osio/osio.go#L137).  Assume we have got invalid cluster_token from auth_service and we tried to make above call `GetName()` and it failed and resolver return result with error and we cached this result.  Later, assume auth_service started returning valid cluster_token but as we have already cached result we will never call resolver again and keep returning cached error.

**Solution:**
Cache the result only when resolver return nil error.